### PR TITLE
numqi.qec update a lot

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -58,9 +58,8 @@ pip install numqi
 
 # for macOS user, metal is the environment name
 conda create -y -n metal
-conda install -y -n metal -c conda-forge ipython pytest matplotlib scipy requests tqdm cvxpy
-conda install -y -n metal -c pytorch pytorch torchvision torchaudio
-# conda-forge/macos/pytorch is broken https://github.com/conda-forge/pytorch-cpu-feedstock/issues/180
+conda install -y -n metal cython ipython pytest matplotlib h5py pandas pylint jupyterlab pillow scipy tqdm opt_einsum cvxpy scs pytest-xdist pytest-cov seaborn pytorch sympy galois mkdocs ipywidgets mkdocs-material mkdocs-jupyter pymdown-extensions mkdocstrings twine platformdirs
+# conda install -y -n metal -c MOSEK MOSEK
 conda activate metal
 ## scs-macos issue, see https://www.cvxgrp.org/scs/install/python.html
 # brew install openblas

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,9 @@ dependencies = [
     'torch',
     'cvxpy',
     'matplotlib',
+    'galois',
+    'platformdirs',
+    'h5py',
 ]
 dynamic = ["version"]
 

--- a/python/numqi/__init__.py
+++ b/python/numqi/__init__.py
@@ -22,5 +22,6 @@ from . import coherence
 
 # mainly for debug
 from . import _torch_op
+from . import _internal
 
 from ._version import __version__, __version_tuple__

--- a/python/numqi/_internal.py
+++ b/python/numqi/_internal.py
@@ -1,0 +1,95 @@
+import os
+import platformdirs
+import h5py
+import numpy as np
+import scipy.sparse
+
+# use hdf5 file to store data
+
+_appname = 'numqi'
+_appauthor = 'husisy'
+_hdf5_filename = 'data.hdf5'
+
+def get_savepath():
+    _appdir = platformdirs.user_data_dir(_appname, _appauthor)
+    if not os.path.exists(_appdir):
+        os.makedirs(_appdir)
+    ret = os.path.join(_appdir, _hdf5_filename)
+    return ret
+
+
+def _save_to_hdf5_enter(_save_func):
+    def hf0(key, data, overwrite:bool=False):
+        with h5py.File(get_savepath(), 'a', libver='latest') as fid:
+            if (key not in fid.keys()) or overwrite:
+                if key in fid.keys():
+                    del fid[key]
+                _save_func(fid, key, data)
+    return hf0
+
+
+@_save_to_hdf5_enter
+def _save_to_hdf5_numpy(fid:h5py.File, key:str, data:np.ndarray):
+    tmp0 = fid.create_dataset(key, data=data)
+    tmp0.attrs['data_format'] = 'numpy'
+
+@_save_to_hdf5_enter
+def _save_to_hdf5_scipy_csr(fid:h5py.File, key:str, data:scipy.sparse.csr_array):
+    grp = fid.create_group(key)
+    grp.attrs['data_format'] = 'scipy_sparse_csr'
+    grp.create_dataset('data', data=data.data)
+    grp.create_dataset('indices', data=data.indices)
+    grp.create_dataset('indptr', data=data.indptr)
+    grp.create_dataset('shape', data=data.shape)
+
+def _load_from_hdf5_scipy_csr(grp):
+    data = grp['data'][:]
+    indices = grp['indices'][:]
+    indptr = grp['indptr'][:]
+    shape = tuple(grp['shape'][:])
+    ret = scipy.sparse.csr_array((data, indices, indptr), shape=shape)
+    return ret
+
+def is_key_in_disk(key:str|None=None):
+    filepath = get_savepath()
+    if not os.path.exists(filepath):
+        ret = [] if (key is None) else False #not exists
+    else:
+        with h5py.File(filepath, 'r', libver='latest') as fid:
+            ret = list(fid.keys()) if (key is None) else (key in fid.keys())
+    return ret
+
+
+def save_to_disk(key:str, data, overwrite:bool=False):
+    import scipy.sparse
+    if isinstance(data, scipy.sparse.sparray):
+        assert data.format=='csr', 'only csr sparse matrix is supported'
+        _save_to_hdf5_scipy_csr(key, data, overwrite=overwrite)
+    elif isinstance(data, np.ndarray):
+        _save_to_hdf5_numpy(key, data, overwrite=overwrite)
+    else:
+        raise TypeError(f'Unsupported data type: {type(data)}. Only numpy arrays and scipy sparse csr matrices are supported.')
+
+
+def load_from_disk(key:str):
+    assert isinstance(key, str), 'key must be a string'
+    with h5py.File(get_savepath(), 'r', libver='latest') as fid:
+        if key not in fid.keys():
+            raise KeyError(f'Key {key} not found in disk')
+        tmp0 = fid[key].attrs['data_format']
+        if tmp0=='numpy':
+            ret = fid[key][:]
+        elif tmp0=='scipy_sparse_csr':
+            ret = _load_from_hdf5_scipy_csr(fid[key])
+        else:
+            raise ValueError(f'Unsupported data format: {tmp0}')
+    return ret
+
+
+def delete_from_disk(key:str):
+    assert isinstance(key, str), 'key must be a string'
+    with h5py.File(get_savepath(), 'a', libver='latest') as fid:
+        if key in fid.keys():
+            del fid[key]
+        else:
+            raise KeyError(f'Key {key} not found in disk')

--- a/python/numqi/entangle/_misc.py
+++ b/python/numqi/entangle/_misc.py
@@ -156,6 +156,8 @@ def check_reduction_witness(rho:np.ndarray, dim:tuple[int], eps:float=-1e-7):
 
     weaker than PPT
 
+    same as SEP for dA*dB<=6
+
     TODO, can positive linear map be parameterized
 
     Parameters:

--- a/python/numqi/entangle/ppt.py
+++ b/python/numqi/entangle/ppt.py
@@ -300,6 +300,23 @@ def cvx_matrix_mlogx(cvxX, sqrt_order=3, pade_order=3):
 
 
 def get_ppt_ree(rho, dimA, dimB, return_info=False, sqrt_order=3, pade_order=3, use_tqdm=True):
+    r'''get the relative entropy of entanglement (REE) using positive partial transpose (PPT) criterion.
+    It is a semi-definite programming (SDP) problem and solved using cvxpy. Matrix logarithm is approximated using the Pade approximation.
+    Refer to [github/cvxquad](https://github.com/hfawzi/cvxquad) and [doi-link](https://doi.org/10.1007/s10208-018-9385-0) for more details.
+
+    Parameters:
+        rho (np.ndarray): density matrix, must be Hermitian, `shape=(dimA*dimB, dimA*dimB)` if single item, or `shape=(n, dimA*dimB, dimA*dimB)` if batch of items
+        dimA (int): dimension of subsystem A
+        dimB (int): dimension of subsystem B
+        return_info (bool): if `True`, then return the dual variable and the objective value
+        sqrt_order (int): order of the square root approximation, must be >=2
+        pade_order (int): order of the Pade approximation, must be >=2
+        use_tqdm (bool): if `True`, then use tqdm to show the progress bar
+
+    Returns:
+        ree (float,np.ndarray): relative entropy of entanglement, `float` if `rho` is a single item, or `np.ndarray` if `rho` is a batch of items
+        info (dict,list[dict]): if `return_info=True`, then return a dictionary containing the dual variable and the objective value.
+    '''
     rho,is_single_item,dimA,dimB,use_tqdm = _check_input_rho_SDP(rho, (dimA,dimB), use_tqdm)
     dim = dimA * dimB
     cvxX = cvxpy.Variable((dim,dim), hermitian=True)

--- a/python/numqi/group/__init__.py
+++ b/python/numqi/group/__init__.py
@@ -14,6 +14,7 @@ from ._internal import (
     get_index_cayley_table,
     group_algebra_product,
     pretty_print_character_table,
+    get_complete_group
 )
 
 from ._lie import (angle_to_su2, angle_to_so3, so3_to_angle, su2_to_angle,

--- a/python/numqi/group/__init__.py
+++ b/python/numqi/group/__init__.py
@@ -17,7 +17,9 @@ from ._internal import (
 )
 
 from ._lie import (angle_to_su2, angle_to_so3, so3_to_angle, su2_to_angle,
-        so3_to_su2, su2_to_so3, get_su2_irrep, get_rational_orthogonal2_matrix)
+        so3_to_su2, su2_to_so3, get_su2_irrep, get_rational_orthogonal2_matrix,
+        su2su2_to_so4_magic, so3_to_su2_magic, su2_to_so3_magic, get_su4_kak_decomposition, get_kak_kernel,
+        diagonalize_unitary_using_two_orthogonals, so4_to_su2su2_magic)
 
 from ._symmetric import (
     get_symmetric_group_cayley_table,

--- a/python/numqi/group/_internal.py
+++ b/python/numqi/group/_internal.py
@@ -379,3 +379,24 @@ def pretty_print_character_table(character_table:np.ndarray, class_list:list):
         tmp1 = ' | '.join(character_table_str[ind0])
         tmp2 = '{' + str(ind0) + '}'
         print(f'| $A_{tmp2}$ | {tmp1} |')
+
+
+def get_complete_group(np_list, zero_eps=1e-5, tag_print=False):
+    np_list = np.stack(np_list, axis=0)
+    assert (np_list.ndim==3) and (np_list.shape[1]==np_list.shape[2])
+    ret = np.stack([np_list[0]], axis=0)
+    hf0 = lambda np1: np.any(np.abs(np1 - ret).max(axis=(1,2)) < zero_eps)
+    for x in np_list[1:]:
+        if not hf0(x):
+            ret = np.append(ret,x[np.newaxis], axis=0)#numpy out-of-place append
+    check_list = [(x,y) for x in range(len(ret)) for y in range(len(ret))]
+    while len(check_list):
+        ind0,ind1 = check_list.pop(0)
+        np1 = ret[ind0] @ ret[ind1]
+        if not hf0(np1):
+            ret = np.append(ret,np1[np.newaxis], axis=0)
+            if tag_print:
+                print(f'{len(ret)}')
+            check_list += [(x,len(ret)-1) for x in range(len(ret))]
+            check_list += [(len(ret)-1,x) for x in range(len(ret))]
+    return ret

--- a/python/numqi/qec/__init__.py
+++ b/python/numqi/qec/__init__.py
@@ -1,6 +1,6 @@
-from ._internal import generate_code_np
+from ._internal import generate_code_np, hf_state
 
-from ._small_code import stabilizer_to_code, get_code_subspace, hf_state
+from ._small_code import stabilizer_to_code, get_code_subspace
 
 from ._qecc import (parse_str_qecc, parse_simple_pauli, generate_code523,
     generate_code422, generate_code442, generate_code642, generate_code883, generate_code8_64_2,
@@ -13,9 +13,18 @@ from ._sdp import (get_code_feasible_constraint, is_code_feasible, get_Krawtchou
 
 from ._pauli import (hf_pauli, get_pauli_with_weight_sparse, make_pauli_error_list_sparse,
     pauli_csr_to_kind, make_error_list, make_asymmetric_error_set,
-    get_weight_enumerator)
+    get_weight_enumerator, get_weight_enumerator_transform_matrix,
+    get_knill_laflamme_matrix_indexing_over_vector, get_qweA_kernel)
 
 from ._grad import knill_laflamme_inner_product, knill_laflamme_hermite_mul
+
+from .transversal import (su2_finite_subgroup_gate_dict, get_su2_finite_subgroup_generator, SearchTransversalGateModel,
+    get_transversal_group, get_transversal_group_info, pick_indenpendent_vector,
+    get_chebshev_center_Axb, get_BD2m_submultiset, get_C2m_submultiset, search_veca_BD_group, search_veca_C_group)
+
+from .picode import get_bg_picode
+
+from .gf4 import str_to_gf4, gf4_to_str, matmul_gf4, get_subspace_minus, get_logical_from_stabilizer
 
 from . import _varqec
 from . import _qecc
@@ -24,3 +33,9 @@ from . import _sdp
 from . import _pauli
 from . import _small_code
 from . import _grad
+from . import transversal
+from . import picode
+from . import gf4
+from . import q623
+from . import q723
+from . import q823

--- a/python/numqi/qec/_internal.py
+++ b/python/numqi/qec/_internal.py
@@ -1,11 +1,40 @@
-import itertools
 import numpy as np
 
-import torch
+# import numqi.utils
+# import numqi.sim
 
-import numqi.gate
-import numqi.utils
-import numqi.sim
+def hf_state(x:str):
+    r'''convert state string to vector, should NOT be used in performance-critical code
+
+    Parameters:
+        x (str): state string, e.g. '0000 1111', supporting sign "+-i", e.g. '0000 -i1111'
+
+    Returns:
+        ret (np.ndarray): shape=(2**n,), state vector
+    '''
+    tmp0 = x.strip().split(' ')
+    tmp1 = []
+    for x in tmp0:
+        if x.startswith('-i'):
+            tmp1.append((-1j, x[2:]))
+        elif x.startswith('i'):
+            tmp1.append((1j, x[1:]))
+        elif x.startswith('-'):
+            tmp1.append((-1, x[1:]))
+        else:
+            x = x[1:] if x.startswith('+') else x
+            tmp1.append((1, x))
+    tmp1 = sorted(tmp1, key=lambda x:x[1])
+    num_qubit = len(tmp1[0][1])
+    assert all(len(x[1])==num_qubit for x in tmp1)
+    index = np.array([int(x[1],base=2) for x in tmp1], dtype=np.int64)
+    coeff = np.array([x[0] for x in tmp1])
+    coeff = coeff/np.linalg.norm(coeff, ord=2)
+    ret = np.zeros(2**num_qubit, dtype=coeff.dtype)
+    ret[index] = coeff
+    return ret
+_state_hf0 = hf_state
+
 
 # def degeneracy(code_i):
 #     # only works for d=3

--- a/python/numqi/qec/_sdp.py
+++ b/python/numqi/qec/_sdp.py
@@ -225,6 +225,12 @@ def get_Krawtchouk_polynomial(q:int, k:int):
     return ret
 
 
+def _get_Shor_weight_enumerator_dual_map(n:int, dimK:int):
+    sx = sympy.symbols('x')
+    sy = sympy.symbols('y')
+    ret = dimK*_MacWilliams_transform((sx+3*sy)/2, (sx-sy)/2, sx, sy, n)
+    return ret
+
 
 def is_code_feasible_linear_programming(num_qubit:int, dimK:int, distance:int):
     r'''check if a quantum code is feasible using linear programming

--- a/python/numqi/qec/_small_code.py
+++ b/python/numqi/qec/_small_code.py
@@ -45,7 +45,7 @@ def stabilizer_to_code(stab_list:list[str], logicalZ_list:list[str], tag_print:b
     TODO: add logicalX_list for fix the phase of code subspace
 
     Parameters:
-        stab_list (list[str]): list of Pauli string for stabilizer, e.g. ['XZZXI', 'IXZZX', 'XIXZZ', 'ZXIXZ']
+        stab_list (list[str]): list of Pauli string for stabilizer generator, e.g. ['XZZXI', 'IXZZX', 'XIXZZ', 'ZXIXZ']
         logicalZ_list (list[str]): logical Z operator list, e.g. ['ZZZZZ']
         tag_print (bool): whether to print the code subspace
 

--- a/python/numqi/qec/_small_code.py
+++ b/python/numqi/qec/_small_code.py
@@ -373,7 +373,7 @@ def get_623_SO5_code(vece_or_abcde, phase=0, return_basis=False, return_mask_zer
         tmp1 = numqi.random.rand_special_orthogonal_matrix(4, seed=np_rng) @ tmp0
         matO = np.concatenate([tmp1, vece.reshape(1,-1)], axis=0)
     else:
-        assert np.abs(vece_or_abcde @ vece_or_abcde - np.eye(5)).max() < zero_eps, 'orthogonal matrix required'
+        assert np.abs(vece_or_abcde @ vece_or_abcde.T - np.eye(5)).max() < zero_eps, 'orthogonal matrix required'
         matO = vece_or_abcde
     veca,vecb,vecc,vecd,vece = matO/2
     coeff0 = np.concatenate([veca+1j*vecb, vecc+1j*vecd], axis=0)

--- a/python/numqi/qec/_varqec.py
+++ b/python/numqi/qec/_varqec.py
@@ -46,7 +46,7 @@ class QECCEqualModel(torch.nn.Module):
         for ind0 in range(self.num_qubit):
             tmp0 = code0.reshape(N0*(2**ind0), 2, 2**(self.num_qubit-ind0-1))
             code0 = torch.einsum(tmp0, [0,1,2], unitary[ind0], [1,3], [0,3,2]).reshape(N0, -1)
-        tmp0 = (code0.conj() @ self.code1.T).reshape(-1)
+        tmp0 = (code0.conj() @ self.code1.T).reshape(-1) #logical unitary equivalence is considered here
         loss = N0 - torch.vdot(tmp0, tmp0).real
         return loss
 

--- a/python/numqi/qec/gf4.py
+++ b/python/numqi/qec/gf4.py
@@ -1,0 +1,119 @@
+import galois
+import numpy as np
+
+GF2 = galois.GF2
+
+def str_to_gf4(x:str|list[str]):
+    isone = isinstance(x, str)
+    if isone:
+        x = [x]
+    N0 = len(x)
+    N1= len(x[0])
+    ret = np.zeros((N0, 2*N1), dtype=np.uint8)
+    for ind0 in range(N0):
+        assert isinstance(x[ind0], str) and (set(x[ind0])<=set('IXYZ'))
+        ret[ind0,:N1] = np.array([(y in 'XY') for y in x[ind0]], dtype=np.uint8)
+        ret[ind0,N1:] = np.array([(y in 'ZY') for y in x[ind0]], dtype=np.uint8)
+    if isone:
+        ret = ret[0]
+    return ret
+
+
+def gf4_to_str(bitXZ:np.ndarray):
+    assert (bitXZ.ndim in (1,2)) and (bitXZ.shape[-1]%2==0)
+    assert (bitXZ.dtype==np.uint8)
+    assert bitXZ.max()<=1
+    isone = bitXZ.ndim==1
+    if isone:
+        bitXZ = bitXZ.reshape(1,-1)
+    N1 = bitXZ.shape[-1]//2
+    ret = [''.join(['IZXY'[2*x0+z0] for x0,z0 in zip(x[:N1], x[N1:])]) for x in bitXZ]
+    if isone:
+        ret = ret[0]
+    return ret
+
+
+def matmul_gf4(np0:np.ndarray|GF2, np1:np.ndarray|GF2)->GF2:
+    assert np0.shape[-1]%2==0
+    assert np0.shape[-1] == np1.shape[(0 if (np1.ndim==1) else -2)]
+    if not isinstance(np0, GF2):
+        assert (np0.dtype==np.uint8) and (np1.dtype==np.uint8)
+        assert (np0.max()<=1) and (np1.max()<=1)
+        np0 = GF2(np0)
+        np1 = GF2(np1)
+    N0 = np0.shape[-1] // 2
+    ind0 = slice(0,N0)
+    ind1 = slice(N0,2*N0)
+    np0a = np0[...,ind0]
+    np0b = np0[...,ind1]
+    if np1.ndim==1:
+        assert np1.shape[0]
+        ret = np0a @ np1[ind1] + np0b @ np1[ind0]
+    else: #np1.ndim>=2
+        ret = np0a @ np1[...,ind1,:] + np0b @ np1[...,ind0,:]
+    return ret
+
+
+def _rand_nonzero_GF2_vector(sz:int|list[int], np_rng:np.random.Generator):
+    while True:
+        x = np_rng.integers(0, 2, size=sz, dtype=np.uint8)
+        if np.any(x!=0):
+            break
+    return x
+
+
+def get_subspace_minus(np0:np.ndarray|GF2, np1:np.ndarray|GF2, tag_reduce:bool=True)->GF2:
+    # np0 - np1
+    assert (np0.ndim==2) and (np1.ndim==2)
+    assert (np0.shape[1]==np1.shape[1])
+    if not isinstance(np0, GF2):
+        assert (np0.dtype==np.uint8) and (np0.max()==1)
+        np0 = GF2(np0)
+    if not isinstance(np1, GF2):
+        assert (np1.dtype==np.uint8) and (np1.max()==1)
+        np1 = GF2(np1)
+    if tag_reduce:
+        np0 = np0.row_space()
+        np1 = np1.row_space()
+        assert np.concatenate([np0,np1]).row_space().shape[0]==np0.shape[0]
+    assert np1.shape[0]<=np0.shape[0]
+    if np0.shape[0]==np1.shape[0]:
+        ret = GF2.zeros((0,np0.shape[1]))
+    else:
+        tmp1 = np.concatenate([np1,np0], axis=0)
+        tmp2 = tmp1.T.row_reduce()
+        rref = tmp2[:tmp2.max(axis=1).sum()]
+        pivot = (rref!=0).argmax(axis=1)
+        ind0 = sorted(set(range(np1.shape[0],tmp1.shape[0])) & set(pivot.tolist()))
+        ret = tmp1[ind0]
+    return ret
+
+
+def get_logical_from_stabilizer(stab:np.ndarray|GF2, tag_reduce:bool=True, seed=None)->tuple[GF2,GF2]:
+    assert (stab.ndim==2) and (stab.shape[1]%2==0)
+    if not isinstance(stab, GF2):
+        assert (stab.dtype==np.uint8) and (stab.max()==1)
+        stab = GF2(stab)
+    if tag_reduce:
+        stab = stab.row_space()
+    n = stab.shape[1]//2
+    k = n - stab.shape[0]
+    assert np.all(matmul_gf4(stab, stab.T)==0)
+    tmp0 = stab.null_space()
+    logical = get_subspace_minus(np.concatenate([tmp0[:,n:], tmp0[:,:n]], axis=1), stab)
+    if k==1:
+        logicalX = logical[:1]
+        logicalZ = logical[1:]
+    else:
+        np_rng = np.random.default_rng(seed)
+        kernel = (logical[:,:n] @ logical[:,n:].T + logical[:,n:] @ logical[:,:n].T)
+        # Every symmetric full-rank (2k,2k) matrix over GF(2) can be transformed (via congruence) into a block diagonal canonical form consisting of blocks
+        vec0 = GF2(_rand_nonzero_GF2_vector((1,len(kernel)), np_rng))
+        for _ in range(k-1):
+            tmp0 = get_subspace_minus((vec0 @ kernel).null_space(), vec0)
+            vec0 = np.concatenate([vec0, GF2(_rand_nonzero_GF2_vector((1,len(tmp0)), np_rng)) @ tmp0], axis=0)
+        tmp0 = get_subspace_minus(GF2(np.eye(len(kernel), dtype=np.uint8)), vec0)
+        vec1 = np.linalg.inv(tmp0 @ kernel @ vec0.T) @ tmp0
+        logicalX = vec0 @ logical
+        logicalZ = vec1 @ logical
+    return logicalX, logicalZ

--- a/python/numqi/qec/picode.py
+++ b/python/numqi/qec/picode.py
@@ -1,0 +1,22 @@
+import numpy as np
+
+def get_bg_picode(b2:int, g:int):
+    # https://arxiv.org/abs/2411.13142 eq(7)
+    assert (b2>=1) and (b2>=g)
+    coeff = np.zeros((b2+g+1, 2), dtype=np.float64)
+    a = np.sqrt((b2-g) / (2*b2))
+    b = np.sqrt((b2+g) / (2*b2))
+    coeff[0,0] = a
+    coeff[b2,0] = b
+    coeff[b2+g,1] = a
+    coeff[g,1]  = b
+    return coeff
+
+# def get_Aydin_picode():
+#     # https://doi.org/10.22331/q-2024-04-30-1321
+#     # https://arxiv.org/abs/2411.13142 appendix A
+#     pass
+
+
+# def get_picode_ABBp():
+#     pass #TODO

--- a/python/numqi/qec/q623.py
+++ b/python/numqi/qec/q623.py
@@ -1,0 +1,94 @@
+import itertools
+import numpy as np
+
+import numqi.gate
+import numqi.random
+
+from ._pauli import make_pauli_error_list_sparse
+
+def get_C10(return_info=False):
+    a = np.sqrt(1/10) #0.3162
+    b = np.sqrt(1/15) #0.2582
+    p3 = np.exp(1j*np.pi/3)
+    p6 = p3*p3
+    code = np.zeros((2,64), dtype=np.complex128)
+    code[0, [0,3,13,21,25,30,37,41,46,49,54,58]] = np.array([a,-a,b,b*p6,b/p6,a,b*p3,b/p3,-a,-b,-a,-a])
+    code[1, [5,9,14,17,22,26,33,38,42,50,60,63]] = np.array([a,a,b,a,b/p6,b*p6,-a,b/p3,b*p3,-b,-a,a])
+    ret = code
+    if return_info:
+        qweA = np.array([1, 0, 0.84, 0, 11.64, 15.36, 3.16])
+        qweB = np.array([1, 0, 0.84, 23.36, 36.6, 39.36, 26.84])
+        su2 = numqi.gate.rz(np.array([1, 1, 1, 1, 2, 3])*2*np.pi/5) #rz(-2*np.pi/5)
+        # TODO lambda_ai
+        info = dict(qweA=qweA, qweB=qweB, su2=su2)
+        ret = code,info
+    return ret
+
+
+def get_SO5_code_basis(phase=0, tag_kron=True, seed=None):
+    np_rng = numqi.random.get_numpy_rng(seed)
+    if phase is None:
+        expia = np.exp(1j*np_rng.uniform(0, 2*np.pi, size=5))
+    else:
+        phase = np.asarray(phase).reshape(-1)
+        assert len(phase) in {1,5}
+        if len(phase)==1:
+            expia = np.exp(1j*phase*np.ones(5))
+        else:
+            expia = np.exp(1j*phase)
+    # hf0 = lambda x: [int(y,base=2) for y in x.split(' ')]
+    # ind0 = hf0('00001 00010 00100 01000 10000')
+    # ind1 = hf0('11110 11101 11011 10111 01111')
+    ind0,ind1 = [1,2,4,8,16], [30,29,27,23,15]
+    basisA = np.zeros((5,32), dtype=np.float64)
+    basisA[np.arange(5), ind0] = 1/np.sqrt(2)
+    basisB = np.zeros((5,32), dtype=np.float64)
+    basisB[np.arange(5), ind1] = 1/np.sqrt(2)
+    basis = basisA + expia.reshape(5,1)*basisB
+    if tag_kron:
+        basis = np.kron(np.eye(2), basis)
+    return basis
+
+
+def get_SO5_code(vece_or_abcde, phase=0, return_info=False, seed=None, zero_eps=1e-10):
+    # https://arxiv.org/abs/2410.07983
+    np_rng = numqi.random.get_numpy_rng(seed)
+    vece_or_abcde = np.asarray(vece_or_abcde)
+    assert vece_or_abcde.shape in {(5,), (5,5)}
+    if vece_or_abcde.shape==(5,):
+        vece = vece_or_abcde
+        assert abs(np.linalg.norm(vece)-1) < zero_eps, 'unit vector required'
+        tmp0 = np.linalg.eigh(np.eye(5) - vece.reshape(-1,1)*vece)[1][:,1:].T
+        tmp1 = numqi.random.rand_special_orthogonal_matrix(4, seed=np_rng) @ tmp0
+        matO = np.concatenate([tmp1, vece.reshape(1,-1)], axis=0)
+    else:
+        assert np.abs(vece_or_abcde @ vece_or_abcde.T - np.eye(5)).max() < zero_eps, 'orthogonal matrix required'
+        matO = vece_or_abcde
+    veca,vecb,vecc,vecd,vece = matO
+    coeff0 = np.concatenate([veca+1j*vecb, vecc+1j*vecd], axis=0)/2
+    coeff1 = np.concatenate([coeff0[5:].conj(), -coeff0[:5].conj()], axis=0)
+    coeff = np.stack([coeff0, coeff1], axis=0)
+    basis = get_SO5_code_basis(phase, seed=np_rng)
+    code = coeff @ basis
+    ret = code
+    if return_info:
+        lambda_ai_dict = dict()
+        for ind0,ind1 in itertools.combinations(range(5), 2):
+            tmp0 = ['I']*6
+            tmp0[5-ind0] = 'X'
+            tmp0[5-ind1] = 'X'
+            lambda_ai_dict[''.join(tmp0)] = -vece[ind0]*vece[ind1]/2
+            tmp0[5-ind0] = 'Y'
+            tmp0[5-ind1] = 'Y'
+            lambda_ai_dict[''.join(tmp0)] = -vece[ind0]*vece[ind1]/2
+            tmp0[5-ind0] = 'Z'
+            tmp0[5-ind1] = 'Z'
+            lambda_ai_dict[''.join(tmp0)] = vece[ind0]*vece[ind0]/2 + vece[ind1]*vece[ind1]/2
+        error_str_list = make_pauli_error_list_sparse(num_qubit=6, distance=3)[0]
+        lambda_ai = np.array([lambda_ai_dict.get(x,0) for x in error_str_list], dtype=np.float64)
+        tmp0 = (vece**4).sum()
+        qweA = np.array([1, 0, 0.5+0.5*tmp0, 0.5-0.5*tmp0, 11.5-0.5*tmp0, 15.5+0.5*tmp0, 3]) #by numerical fitting
+        qweB = np.array([1, 0, 0.5+0.5*tmp0, 23+tmp0, 37-2*tmp0, 41-tmp0, 25.5+1.5*tmp0])
+        info = dict(coeff=coeff, basis=basis, phase=phase, vece=vece, matO=matO, lambda_ai=lambda_ai, qweA=qweA, qweB=qweB)
+        ret = code, info
+    return ret

--- a/python/numqi/qec/q723.py
+++ b/python/numqi/qec/q723.py
@@ -1,0 +1,836 @@
+import itertools
+import numpy as np
+import scipy.linalg
+
+import numqi.gate
+
+from ._pauli import hf_pauli
+
+def get_cyclic_code(lambda2:float, sign:str='++'):
+    assert (lambda2>=0) and (lambda2<=7)
+    assert sign in {'++', '+-', '-+', '--'} #sign of c1 and c3
+    x = np.sqrt(lambda2).item()
+    s7 = np.sqrt(7)
+    assert np.all(0<=x) and np.all(x<=s7)
+    c0 = np.sqrt(s7*x+8)/8
+    c1 = (7**(1/4))*np.sqrt(x)/8 * (1 if sign[0]=='+' else -1)
+    tmp0 = 0.4*np.sqrt(max(7*c0*c0-15*s7*x/64,0)) * (1 if sign[1]=='+' else -1)
+    c3 = 0.4*s7*c0 + tmp0
+    c2 = -2*c3 + s7*c0
+    c4 = -np.sqrt(3)*c1
+    coeff = np.array([c0,c1,c2,c3,c4])
+    basis = get_723_cyclic_code_basis()
+    lambda_ai_dict = dict()
+    for ind0,ind1 in itertools.combinations(range(7), 2):
+        tmp0 = ['I']*7
+        tmp0[ind0] = 'X'
+        tmp0[ind1] = 'X'
+        lambda_ai_dict[''.join(tmp0)] = x/(3*np.sqrt(7))
+        tmp0[ind0] = 'Y'
+        tmp0[ind1] = 'Y'
+        lambda_ai_dict[''.join(tmp0)] = x/(3*np.sqrt(7))
+        tmp0[ind0] = 'Z'
+        tmp0[ind1] = 'Z'
+        lambda_ai_dict[''.join(tmp0)] = x/(3*np.sqrt(7))
+    return coeff, lambda_ai_dict, basis
+
+
+def get_723_cyclic_code_basis():
+    # equivalent construction but not efficient
+    # tmp0 = '''0000000
+    #     0000011 0000110 0001100 0011000 0110000 1100000 1000001
+    #     0000101 0001010 0010100 0101000 1010000 0100001 1000010
+    #     0001001 0010001 0010010 0100010 0100100 1000100 1001000
+    #     0001111 0011110 0111100 1111000 1110001 1100011 1000111
+    #     0011011 0110110 1101100 1011001 0110011 1100110 1001101
+    #     0011101 0111010 1110100 1101001 1010011 0100111 1001110
+    #     0101011 1010110 0101101 1011010 0110101 1101010 1010101
+    #     0010111 0101110 1011100 0111001 1110010 1100101 1001011
+    #     1111110 1111101 1111011 1110111 1101111 1011111 0111111'''
+    # tmp1 = [numqi.qec._internal.hf_state(x.strip()) for x in tmp0.strip().split('\n')]
+    # basis = np.stack([tmp1[0], (tmp1[1]+tmp1[2]+tmp1[3])/np.sqrt(3), tmp1[8],
+    #                     (tmp1[4]+tmp1[5]+tmp1[6]+tmp1[7])/2, tmp1[9]], axis=0)
+    # Xseven = hf_pauli('X'*7)
+    # basis_not = basis @ Xseven
+    ret = np.zeros((2,5,128), dtype=np.float64)
+    ret[0,0,0] = 1
+    ret[0,1,[3,5,6,9,10,12,17,18,20,24,33,34,36,40,48,65,66,68,72,80,96]] = 1/np.sqrt(21)
+    ret[0,2,[23,46,57,75,92,101,114]] = 1/np.sqrt(7)
+    ret[0,3,[15,27,29,30,39,43,45,51,53,54,58,60,71,77,78,83,85,86,89,90,99,102,105,106,108,113,116,120]] = 1/np.sqrt(28)
+    ret[0,4,[63,95,111,119,123,125,126]] = 1/np.sqrt(7)
+    ret[1,0,127] = 1
+    ret[1,1,[31,47,55,59,61,62,79,87,91,93,94,103,107,109,110,115,117,118,121,122,124]] = 1/np.sqrt(21)
+    ret[1,2,[13,26,35,52,70,81,104]] = 1/np.sqrt(7)
+    ret[1,3,[7,11,14,19,21,22,25,28,37,38,41,42,44,49,50,56,67,69,73,74,76,82,84,88,97,98,100,112]] = 1/np.sqrt(28)
+    ret[1,4,[1,2,4,8,16,32,64]] = 1/np.sqrt(7)
+    return ret
+
+
+def get_2I_lambda0(theta:float, phi:float, sign:str, return_info:bool=False):
+    assert sign in '+-'
+    s = np.sqrt
+    basis0 = np.zeros((4,128), dtype=np.float64)
+    basis0[0, [0,63,95,111,113,114,116,120]] = np.array([1,1,-1,1,-1,1,1,1])/s(8)
+    basis0[1, [19,28,37,42,70,73]] = np.array([-1,1,1,-1,1,-1])/s(6)
+    basis0[2, [21,26,38,41,67,76]] = np.array([1,-1,1,-1,1,-1])/s(6)
+    basis0[3, [22,25,35,44,69,74]] = np.array([-1,1,-1,1,1,-1])/s(6)
+    basis1 = (hf_pauli('X'*7) @ basis0.T).T.copy()
+    ct = np.cos(theta)
+    st = np.sin(theta)
+    s3 = s(1/3)
+    a = -np.cos(phi)*st*s3
+    b = (np.cos(phi-np.pi/3) + np.cos(phi+np.pi/3)) * ct*s3 + s(1/30)
+    c = -np.cos(phi-np.pi/3) * st*s3
+    d = np.cos(phi-np.pi/3) * ct*s3 - s(1/30)
+    e = (np.cos(phi-np.pi/3) - np.cos(phi)) * st*s3
+    f = np.cos(phi+np.pi/3) * ct*s3 - s(1/30)
+    coeff = np.array([s(2/5)*(1 if sign=='+' else -1), a+1j*b, c+1j*d, e+1j*f])
+    code = np.stack([coeff@basis0, coeff@basis1], axis=0)
+    ret = code
+    if return_info:
+        qweA = np.array([1,0,0,0,21,0,42,0]) + 8*st*st*np.array([0,0,0,0,-1,3,-3,1])
+        qweB = np.array([1,0,0,21,21,126,42,45]) + 8*st*st*np.array([0,0,0,-1,4,-6,4,-1])
+        su2 = numqi.gate.rz(np.array([2,2,2,4,4,4,4])*np.pi/5) #rz(2*np.pi/5)
+        I,X,Y,Z = numqi.gate.I, numqi.gate.X, numqi.gate.Y, numqi.gate.Z
+        hfR = lambda a,b,t=1: I*np.cos(t*np.pi/5) + 1j*np.sin(t*np.pi/5)/np.sqrt(5) * (a*Y + b*Z)
+        if sign=='+':
+            transR = hfR(-2,1)
+            tmp0 = [(2, 1, 1), (-2, 1, 1), (2, 1, 1), (2, -1, 2), (2, -1, 2), (2, -1, 2), (-2, -1, 2)]
+        else:
+            transR = hfR(2,1)
+            tmp0 = [(-2, 1, 1), (2, 1, 1), (-2, 1, 1), (-2, -1, 2), (-2, -1, 2), (-2, -1, 2), (2, -1, 2)]
+        su2R = [hfR(a,b,t) for a,b,t in tmp0]
+        info = dict(basis0=basis0, basis1=basis1, theta=theta, phi=phi, sign=sign, su2=su2, su2R=su2R, transR=transR, qweA=qweA, qweB=qweB)
+        ret = code, info
+    return ret
+
+
+def get_2I_lambda075(t:float, sign=None, return_info:bool=False):
+    assert abs(t) <= np.sqrt(5/16)
+    if sign is None:
+        sign = np.ones(3, dtype=np.float64)
+    else:
+        sign = tuple(int(x) for x in sign)
+        assert (len(sign) == 3) and all(x in [1,-1] for x in sign)
+        sign = np.asarray(sign)
+    basis0 = np.zeros((4,128), dtype=np.float64)
+    basis0[0, 0] = 1
+    basis0[1, [7, 11, 19, 35, 67, 124]] = np.array([1,-1,1,1,1,-1])/np.sqrt(6)
+    basis0[2, [29, 45, 54, 58, 78, 85, 90, 102, 105, 113]] = np.array([1,1,-1,1,1,-1,1,-1,1,-1])/np.sqrt(10)
+    basis0[3, [30, 46, 53, 57, 77, 86, 89, 101, 106, 114]] = np.array([1,1,-1,1,1,-1,1,-1,1,-1])/np.sqrt(10)
+    basis1 = (hf_pauli('X'*7) @ basis0.T).T
+    b = sign[2]*np.sqrt(max(0,5/16-t*t))
+    coeff = np.array([np.sqrt(1/10), 1j*sign[0]*np.sqrt(3/20), sign[1]/4-t-1j*b, sign[1]/4+t+1j*b])
+    code = np.stack([coeff@basis0, coeff@basis1], axis=0)
+    ret = code
+    if return_info:
+        su2 = numqi.gate.rz(np.array([1,1,1,1,1,2,2])*2*np.pi/5)
+        t2 = t*t
+        qweA = np.array([1,0,3/4,0,12+24*t2,45/2-72*t2,81/4+72*t2,15/2-24*t2])
+        qweB = np.array([1,0,3/4,63/4+24*t2,99/2-96*t2,153/2+144*t2,291/4-96*t2,159/4+24*t2])
+        lambda_ai = np.zeros(210, dtype=np.float64)
+        lambda_ai[[201, 205, 209]] = -0.5 #IIIIIXX IIIIIYY IIIIIZZ
+        I,X,Y,Z = numqi.gate.I, numqi.gate.X, numqi.gate.Y, numqi.gate.Z
+        hfR = lambda a,b,t=1: I*np.cos(t*np.pi/5) + 1j*np.sin(t*np.pi/5)/np.sqrt(5) * (a*Y + b*Z)
+        tmp0 = int(sign[0]),int(sign[1])
+        if tmp0==(-1,-1):
+            transR = hfR(2,1)
+            tmp1 = [(-2, -1, 1), (-2, -1, 1), (-2, -1, 1), (2, -1, 1), (-2, -1, 1), (-2, 1, 2), (-2, 1, 2)]
+        elif tmp0==(1, -1):
+            transR = hfR(-2,1)
+            tmp1 = [(2, -1, 1), (2, -1, 1), (2, -1, 1), (-2, -1, 1), (2, -1, 1), (2, 1, 2), (2, 1, 2)]
+        elif tmp0==(-1, 1):
+            transR = hfR(2,1)
+            tmp1 = [(-2, -1, 1), (-2, -1, 1), (-2, -1, 1), (2, -1, 1), (-2, -1, 1), (2, 1, 2), (2, 1, 2)]
+        elif tmp0==(1, 1):
+            transR = hfR(-2,1)
+            tmp1 = [(2, -1, 1), (2, -1, 1), (2, -1, 1), (-2, -1, 1), (2, -1, 1), (-2, 1, 2), (-2, 1, 2)]
+        su2R = [hfR(a,b,t) for a,b,t in tmp1]
+        info = dict(basis0=basis0, basis1=basis1, coeff=coeff, t=t, sign=sign, su2=su2,
+                qweA=qweA, qweB=qweB, lambda_ai=lambda_ai, transR=transR, su2R=su2R)
+        ret = code, info
+    return ret
+
+
+def get_BD12_veca1112222(sign=None, return_info=False):
+    if sign is None:
+        sign = np.array([1,1,1,1,1,1,-1,1,-1,1])
+    else:
+        sign = tuple(int(x) for x in sign)
+        assert (len(sign)==10) and all(x in [-1,1] for x in sign)
+    assert (sign[2]*sign[4]*sign[7]*sign[8])==-1
+    assert (sign[1]*sign[3]*sign[5]*sign[6])==-1
+    basis0 = np.zeros((10, 128), dtype=np.complex128)
+    basis0[np.arange(9), [0,53,54,58,60,85,90,99,105]] = 1
+    basis0[9, 14] = 1j
+    basis1 = (hf_pauli('X'*7) @ basis0.T).T
+    coeff = np.sqrt(np.array([10,12,5,8,5,18,12,15,15,20])/120) * sign
+    code = np.stack([coeff@basis0, coeff@basis1], axis=0)
+    ret = code
+    if return_info:
+        su2 = numqi.gate.rz(np.array([1,1,1,2,2,2,2])*2*np.pi/6)
+        A2 = 269/150
+        qweA = np.array([1,0,A2,0,21-2*A2,0,42+A2,0])
+        qweB = np.array([1,0,A2,21+3*A2,21-2*A2,126-6*A2,42+A2,45+3*A2])
+        info = dict(sign=sign, basis0=basis0, basis1=basis1, coeff=coeff, su2=su2, qweA=qweA, qweB=qweB)
+        ret = code, info
+    return ret
+
+
+def get_BD12_veca0122233(a:float, sign=None, return_info=False):
+    ## TODO
+    # [0,3,4,5,6,1,2]
+    # [0,2,2,2,4,6,6]
+    # [2,2,2,2,4,4,6]
+    # [0,2,2,4,4,4,6]
+    # [1,1,2,3,4,5,6]
+    # [2,2,2,4,4,4,4]
+    s = np.sqrt
+    assert 0 <= a <= s(2/3)
+    if sign is None:
+        sign = np.array([1,1,1,1], dtype=np.int64)
+    else:
+        sign = tuple(int(x) for x in sign)
+        assert len(sign) == 4
+        assert all(x in [1,-1] for x in sign)
+        sign = np.asarray(sign, dtype=np.int64)
+    assert (sign[0]*sign[1]*sign[2]*sign[3])==1
+    basis0 = np.zeros((4,128), dtype=np.complex128)
+    basis0[0, [0,101,105,113, 3,102,106,114]] = np.array([1,1,1,1,-1,-1,-1,-1])/s(8)
+    basis0[1, [37,38,49,41,42,50,64,67]] = 1j/np.sqrt(8)
+    basis0[2, [28,31]] = 1j/np.sqrt(2)
+    basis0[3, [92,95]] = np.array([1,-1]) / np.sqrt(2)
+    basis1 = (hf_pauli('X'*7) @ basis0.T).T
+    tmp0 = s(max(0,2/3-a*a))
+    coeff = np.array([a,tmp0,s(1/2)*a,s(1/2)*tmp0])*sign
+    code = np.stack([coeff@basis0,coeff@basis1], axis=0)
+    ret = code
+    if return_info:
+        su2 = numqi.gate.rz(np.array([0,1,2,2,2,3,3])*2*np.pi/6)
+        lambda_ai = np.zeros(210, dtype=np.float64)
+        lambda_ai[[83,92,101,120,124,128,129,133,137,156,160,164]] = np.array([-1,-1,-1,1,1,1,1,1,1,1,1,1])/3
+        lambda_ai[[38,47,56,201]] = 1/3 - a*a
+        lambda_ai[29] = 3*a*a - 1
+        lambda_ai[62] = -2*a*s(max(0,2/3-a*a)) * sign[0]*sign[1]
+        lambda_ai[71] = a*s(max(0,2/3-a*a)) * sign[0] * sign[1]
+        lambda_ai[205] = -2*a*a + 2/3
+        A2 = 29/9 - 8*a*a + 12*a**4
+        # A2 range [17/9, 29/9]
+        qweA = np.array([1,0,A2,0,21-2*A2,0,42+A2,0])
+        qweB = np.array([1,0,A2,21+3*A2,21-2*A2,126-6*A2,42+A2,45+3*A2])
+        info = dict(a=a, sign=sign, coeff=coeff, basis0=basis0, basis1=basis1, su2=su2, lambda_ai=lambda_ai, qweA=qweA, qweB=qweB)
+        ret = (code, info)
+    return ret
+
+
+def get_BD14(a:float, sign=None, return_info=False):
+    assert 0 <= a <= np.sqrt(1/14)
+    if sign is None:
+        sign = np.ones(5, dtype=np.float64)
+    else:
+        sign = tuple(int(x) for x in sign)
+        assert len(sign) == 5
+        assert all(x in [1,-1] for x in sign)
+        sign = np.asarray(sign)
+    s = np.sqrt
+    basis0 = np.zeros((5,128), dtype=np.complex128)
+    basis0[0, [0,14,86,89]] = np.array([1,s(2)*1j,1,s(2)])/s(6)
+    basis0[[1,2], [19,21]] = 1j
+    basis0[3, [60,101]] = np.array([s(3),2])/s(7)
+    basis0[4, [58,99]] = np.array([s(3),-2])/s(7)
+    basis1 = (hf_pauli('X'*7) @ basis0.T).T
+    coeff = np.array([s(3/7), a, s(max(0,1/14-a*a)), s(3/14+a*a), s(2/7-a*a)])*sign
+    code = np.stack([coeff@basis0, coeff@basis1], axis=0)
+    ret = code
+    if return_info:
+        # TODO BD14 [2,2,4,4,4,4,6]
+        su2 = numqi.gate.rz(np.array([1,2,3,4,5,5,6])*np.pi/7)
+        lambda_ai = np.zeros(210, dtype=np.float64)
+        lambda_ai[[29,38,83,92,119,155,191]] = np.array([1,-1,-1,-1,1,-1,-1])/7
+        lambda_ai[[47,128,182]] = np.array([-1,1,-1])*3/7
+        lambda_ai[74] = 5/7
+        lambda_ai[[101,110]] = np.array([-1,1])*(-4*a*a + 1/7)
+        lambda_ai[[56,146]] = 16/7*a*a - 11/49
+        lambda_ai[[65,137]] = -16/7*a*a - 3/49
+        lambda_ai[209] = 12/7*a*a - 17/49
+        lambda_ai[[164,173]] = np.array([-1,1])*(-12/7*a*a + 3/49)
+        lambda_ai[200] = -12/7*a*a - 11/49
+        lambda_ai[[183,187]] = sign[1]*sign[2]*2*a*s(max(0,1/14-a*a)) - sign[3]*sign[4]*2/7*s(3/14+a*a)*s(2/7-a*a)
+        # 2*coeff[1]*coeff[2] - 2/7*coeff[3]*coeff[4]
+        A2 = 3701/2401 -1384/343*a*a + 2768/49*a**4 - np.prod(sign[1:])*16/7*a*s(max(0,1/14-a*a))*s(3/14+a*a)*s(2/7-a*a)
+        # A2 range [1.44? 1.54?]
+        qweA = np.array([1,0,A2,0,21-2*A2,0,42+A2,0])
+        qweB = np.array([1,0,A2,21+3*A2,21-2*A2,126-6*A2,42+A2,45+3*A2])
+        info = dict(a=a, sign=sign, coeff=coeff, basis0=basis0, basis1=basis1, su2=su2, lambda_ai=lambda_ai, qweA=qweA, qweB=qweB)
+        ret = (code, info)
+    return ret
+
+
+def get_BD16_5theta(theta, return_info=False):
+    theta = np.asarray(theta)
+    assert len(theta)==5
+    ind0 = [0,3,61,62,93,94,109,110,117,118,121,122]
+    # [127, 124, 66, 65, 34, 33, 18, 17, 10, 9, 6, 5]
+    basis0 = np.zeros((len(ind0), 128), dtype=np.complex128)
+    basis0[np.arange(len(ind0)), ind0] = 1
+    basis1 = (hf_pauli('XXXXXII') @ basis0.T).T
+    phase = np.exp(1j*np.array([np.pi/2, np.pi/2] + [y for x in theta for y in [x,-x]]))
+    coeff = np.array([np.sqrt(3)/4]*2 + [1/4]*10) * phase
+    code = np.stack([coeff@basis0,coeff@basis1], axis=0)
+    ret = code
+    if return_info:
+        su2X = [numqi.gate.X]*5 + [numqi.gate.I]*2
+        su2Z = numqi.gate.rz(np.array([3,3,3,3,3,4,-4])*np.pi/4)
+        A2 = np.cos(2*(theta.reshape(-1,1)-theta)).sum()/16 + 53/16
+        # A2 range [53/16, 78/16]
+        qweA = np.array([1,0,A2,0,21-2*A2,0,42+A2,0])
+        qweB = np.array([1,0,A2,21+3*A2,21-2*A2,126-6*A2,42+A2,45+3*A2])
+        info = dict(theta=theta, coeff=coeff, basis0=basis0, basis1=basis1, su2X=su2X, su2Z=su2Z, qweA=qweA, qweB=qweB)
+        ret = code, info
+    return ret
+
+
+def get_BD16_veca1222233(theta0:float, theta1:float, sign=None, return_info:bool=False):
+    if sign is None:
+        sign = np.array([1,1,1,1,1,1,1], dtype=np.int64)
+    else:
+        sign = tuple(int(x) for x in sign)
+        assert len(sign) == 7
+        assert all(x in [1,-1] for x in sign)
+        sign = np.asarray(sign, dtype=np.int64)
+    s = np.sqrt
+    basis0 = np.zeros((7, 128), dtype=np.complex128)
+    basis0[np.arange(7), [0,60,78,85,89,114,35]] = np.array([1,1,1,1,1,1,1j])
+    basis1 = (hf_pauli('X'*7) @ basis0.T).T
+    coeff = np.array([np.exp(1j*theta0), s(3), s(3), s(2), s(2), np.exp(1j*theta1), 2])/4 * sign
+    code = np.stack([coeff@basis0,coeff@basis1], axis=0)
+    ret = code
+    if return_info:
+        su2 = numqi.gate.rz(np.array([1,2,2,2,2,3,3])*2*np.pi/8)
+        a = np.cos(2*theta0) + np.cos(2*theta1)
+        b = np.cos(2*theta0-2*theta1)
+        qweA = np.array([1, 0, 21/8, 1/8*(2-a), 1/16*(215+18*a+b), 3/16*(29-14*a-b),
+                        1/16*(635+38*a+3*b), 1/16*(25-12*a-b)])
+        qweB = np.array([1, 0, 21/8, 1/16*(441+10*a+b), 1/16*(352-48*a-4*b), 1/16*(1590+84*a+6*b),
+                        1/16*(846-64*a-4*b), 1/16*(809+18*a+b)])
+        info = dict(basis0=basis0, basis1=basis1, coeff=coeff, su2=su2,
+                    theta0=theta0, theta1=theta1, sign=sign, qweA=qweA, qweB=qweB)
+        ret = code, info
+    return ret
+
+
+def get_BD16_degenerate(theta:float|None=None, sign=None, return_info=True, seed=None):
+    np_rng = np.random.default_rng(seed)
+    if theta is None:
+        theta = np_rng.uniform(0, 2*np.pi)
+    if sign is None:
+        sign = np_rng.integers(2, size=8)*2-1
+        sign[5] = -sign[0]*sign[1]*sign[4]
+    assert (sign.shape==(8,)) and all((x==1 or x==-1) for x in sign)
+    assert sign[0]*sign[1]*sign[4]*sign[5]==-1
+    basis0 = np.zeros((8, 128), dtype=np.float64)
+    basis0[np.arange(8), [0,36,92,113,11,47,114,87]] = 1
+    basis1 = (hf_pauli('X'*7) @ basis0.T).T
+    s = np.sqrt
+    tmp0 = np.array([s(3/32), s(3/32), s(3/16), s(1/8), s(5/32), s(5/32), s(1/8), 1/4])
+    tmp1 = np.exp(1j*theta)
+    coeff = np.array([1j, 1j, tmp1, tmp1, 1j*tmp1, 1j*tmp1, tmp1, 1]) * tmp0 * sign
+    code = np.stack([coeff@basis0, coeff@basis1], axis=0)
+    ret = code
+    if return_info:
+        lambda_a = np.zeros(210, dtype=np.float64)
+        lambda_a[38] = 1 #ZIZIIII
+        lambda_a[[47,65,74,128,146,155]] = -1/4 #ZIIZIII ZIIIIZI ZIIIIIZ IIZZIII IIZIIZI IIZIIIZ
+        lambda_a[92] = -3/8 #IZIZIII
+        lambda_a[[110,119]] = 1/8 #IZIIIZI IZIIIIZ
+        lambda_a[164] = 3/8 #IIIZZII
+        lambda_a[[173,182]] = 1/4 #IIIZIZI IIIZIIZ
+        lambda_a[[191,200]] = -1/8 #IIIIZZI IIIIZIZ
+        lambda_a[209] = 1/2 #IIIIIZZ
+        lambda_a[93] = -1/8*sign[0]*sign[1] #IXIIXII
+        lambda_a[97] = 1/8*sign[0]*sign[1] #IYIIYII
+        lambda_a[[201,205]] = 1/4*sign[3]*sign[6] #IIIIIXX IIIIIYY
+        tmp0 = np.sort(np.roots([32, -128, 133, -30]).real) # -30 + 133x - 128xx + 32xxx=0
+        lambda_ab_EVL = np.array([0, tmp0[0], 1/2, 3/4,3/4, 7/8,7/8, 1,1,1,1,1,1,1,1, 9/8,9/8, tmp0[1], 5/4,5/4, 3/2, tmp0[2]])
+        c2t = np.cos(2*theta)
+        qweA = np.array([1,0,9/4,7/32,209/16,9,571/16,89/32]) + c2t*np.array([0,0,0,7/32,-55/16,9,-137/16,89/32])
+        qweB = np.array([1,0,9/4,403/16,221/8,189/2,457/8,773/16]) + c2t*np.array([0,0,0,-41/16,89/8,-18,103/8,-55/16])
+        su2 = numqi.gate.rz(np.array([3,3,4,4,5,6,6])*2*np.pi/8)
+        ret = code, dict(theta=theta, sign=sign, coeff=coeff, basis0=basis0, basis1=basis1, su2=su2,
+                    qweA=qweA, qweB=qweB, lambda_a=lambda_a, lambda_ab_EVL=lambda_ab_EVL)
+    return ret
+
+
+def get_BD18(theta:float, root:int=0, sign=None, return_info=True):
+    assert root in {0,1}
+    # import sympy, sympy.abc
+    # x = sympy.abc.x
+    # [x.n(24) for x in sympy.real_roots(-25+3222*x*x-49329*x**4-58320*x**6+209952*x**8)][3:-1]
+    # np.polynomial.Polynomial([-25,0,3222,0,-49329,0,-58320,0,209952]).roots()[5:7]
+    b = [0.0949564154092439210937958, 0.230377064728512746573312][root]
+    if sign is None:
+        sign = np.ones(8, dtype=np.int64)
+    else:
+        sign = np.array([int(x) for x in sign], dtype=np.int64)
+        assert np.all((sign*sign)==1)
+    # sign[[1,2,3,6]] can be set {0,1} arbitrarily
+    sign[0] = 1 #sign[a] is controlled by theta
+    sign[4] = -sign[1]*sign[2]*sign[3] #sign[e]=-sign[bcd]
+    sign[5] = -sign[3] #sign[d]==-sign[f]
+    sign[7] = sign[1]*sign[3]*sign[6]
+    s = np.sqrt
+    d = 1/s(36*b*b+14).item()
+    coeff = np.array([1/s(18)*np.exp(1j*theta), b, s(max(0, 1/18-b*b)),
+            d, s(1/9-b*b), s(b*b+d*d+1/18), s(1/3-2*d*d), s(7/18)])*sign
+    basis0 = np.zeros((8,128), dtype=np.complex128)
+    basis0[[0,1,2,3,4,5], [0,58,60,90,99,101]] = 1
+    basis0[6, [86,105]] = 1/s(2)
+    basis0[7, [54,14,25]] = np.array([s(2),-s(2)*1j,s(3)*1j])/s(7)
+    basis1 = (hf_pauli('X'*7) @ basis0.T).T
+    code = np.stack([coeff@basis0, coeff@basis1], axis=0)
+    ret = code
+    if return_info:
+        su2 = numqi.gate.rz(np.array([2,2,4,6,6,6,8])*np.pi/9)
+        lambda_ai = np.zeros(210, dtype=np.float64)
+        lambda_ai[110] = -1/9
+        lambda_ai[[ 29,  38,  47,  74,  83, 119, 155]] = np.array([1,-1,-1,1,-1,1,-1])/3
+        lambda_ai[[56,65]] = (4*b*b - 1/9)*np.array([1,-1])
+        lambda_ai[146] = 4*b*b + 1/9
+        lambda_ai[164] = -4*b*b - 1/3
+        lambda_ai[209] = -4*b*b - 5/9
+        lambda_ai[92] = -4*d*d -1/9
+        lambda_ai[182] = -4*d*d + 1/3
+        lambda_ai[191] = -4*d*d + 5/9
+        lambda_ai[[101, 128]] = 4*d*d - 1/9
+        lambda_ai[137] = - 4*b*b - 4*d*d + 1/3
+        lambda_ai[173] = 4*b*b + 4*d*d - 5/9
+        lambda_ai[200] = 4*b*b + 4*d*d - 7/9
+        lambda_ai[[21,25]] = sign[1]*sign[3]*2*(b*d + s(1/18)*s(1/3-2*d*d)) #2*(b*d + s(1/7)*g*h)
+        lambda_ai[[165,169]] = sign[2]*sign[7]*(2/3*s(1/18-b*b) - s(2)*s((1/9-b*b)*(1/3-2*d*d))) #s(8/7)*c*h - s(2)*e*g)
+        lambda_ai[[183,187]] = sign[1]*sign[2]*2*(b*s(1/18-b*b) + s((1/9-b*b)*(b*b+d*d+1/18))) #2*b*c + 2*e*f
+        lambda_ai[[156,160]] = sign[1]*sign[7] * (2/3*b + s(2)*s(1/3-2*d*d)*(d-s(b*b+d*d+1/18))) # s(8/7)*b*h + s(2)*g*(d-f)
+        tmp0 = s((1 - 27*b*b + 162*b**4)*(1-6*d*d))
+        tmp2 = -1 + 9*b*b + 27*d*d - 54*d**4
+        A2 = (-257/6 + 112*b*b + 1802*d*d/3 + 462*d**4 - 8/(27*s(3))*tmp0 + 4/9*d*(-1 + 6*d*d)* s(2+36*b*b+36*d*d)
+            + 8/27*b*(6*d*s(6-36*d*d) + s((1 - 27*b*b + 162*b**4)*(1 + 18*b*b + 18*d*d)) - s(6)*s(tmp2)))
+        # A2 be either 2.548? or 2.159?
+        st2 = np.sin(theta)**2
+        tmp0 = np.array([1,0,A2,0,21-2*A2,0,42+A2,0])
+        tmp1 = np.array([0,0,0,20,-176,408,-368,116])/81
+        qweA = tmp0 + st2*tmp1
+        tmp0 = np.array([1,0,A2,21+3*A2,21-2*A2,126-6*A2,42+A2,45+3*A2])
+        tmp1 = np.array([0, 0, 0, -96, 464, -816, 624, -176])/81
+        qweB = tmp0 + st2*tmp1
+        info = dict(b=b, d=d, root=root, sign=sign, su2=su2, theta=theta, coeff=coeff, basis0=basis0, basis1=basis1, lambda_ai=lambda_ai, qweA=qweA, qweB=qweB)
+        ret = code, info
+    return ret
+
+
+def get_BD18_LP(coeff2=None, sign=None, return_info=True, seed=None):
+    matA = np.array([[1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                     [0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0],
+                     [0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0],
+                     [0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1],
+                     [0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0],
+                     [1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0]], dtype=np.int64)
+    vecb = np.array([1/6, 1/6, 1/6, 1/6, 2/9, 2/9])
+    if sign is None:
+        sign = np.array([1]*14, dtype=np.int64)
+    else:
+        sign = tuple(int(x) for x in sign)
+        assert len(sign) == 14
+        assert all(x in [1,-1] for x in sign)
+        sign = np.asarray(sign, dtype=np.int64)
+    if coeff2 is None:
+        np_rng = np.random.default_rng(seed)
+        matB = scipy.linalg.null_space(matA) #(12,6)
+        tmp0 = np_rng.normal(size=6)
+        tmp1 = matB @ (tmp0/np.linalg.norm(tmp0))
+        tmp2 = np_rng.uniform(-1/18/tmp1.max(),-1/18/tmp1.min())
+        tmp3 = 1/18 + tmp2*tmp1
+        coeff = np.sqrt(np.array([1/18,5/18] + tmp3.tolist())) * sign
+    else:
+        assert (coeff2.shape==(14,)) and (coeff2.min()>=0)
+        coeff2 = np.asarray(coeff2).copy()
+        assert abs(coeff2[0] - 1/18) < 1e-10
+        assert abs(coeff2[1] - 5/18) < 1e-10
+        assert np.abs(matA @ coeff2[2:] - vecb).max() < 1e-10
+        coeff2[0] = 1/8
+        coeff2[1] = 5/8
+        coeff = np.sqrt(coeff2) * sign
+    basis0 = np.zeros((14, 128), dtype=np.complex128)
+    basis0[[0,1], [0,7]] = 1
+    basis0[np.arange(2,14), [57,58,60,89,90,92,105,106,108,113,114,116]] = 1j
+    basis1 = (hf_pauli('X'*7) @ basis0.T).T
+    code = np.stack([coeff@basis0,coeff@basis1], axis=0)
+    ret = code
+    if return_info:
+        su2 = numqi.gate.rz(np.array([4,4,4,4,6,6,6])*np.pi/9)
+        info = dict(su2=su2, coeff=coeff, basis0=basis0, basis1=basis1)
+        ret = code, info
+    return ret
+
+
+def get_BD20(a:float, sign=None, return_info=False):
+    assert 0 <= a <= np.sqrt(1/5)
+    if sign is None:
+        sign = np.ones(5, dtype=np.float64)
+    else:
+        sign = tuple(int(x) for x in sign)
+        assert len(sign) == 5
+        assert all(x in [1,-1] for x in sign)
+        sign = np.asarray(sign)
+    s = np.sqrt
+    si = lambda x: np.sqrt(x)*1j
+    basis0 = np.zeros((5,128), dtype=np.complex128)
+    basis0[0, [0,13,60,102]] = np.array([1,s(2)*1j,s(3),1])/s(7)
+    basis0[[1,2], [19,35]] = 1
+    basis0[3, [85,90]] = np.array([2,s(5)])/3
+    basis0[4, [101,106]] = np.array([2,-s(5)])/3
+    basis1 = (hf_pauli('X'*7) @ basis0.T).T
+    coeff = np.array([s(7/20), a*1j, si(max(0,1/5-a*a)), s(7/20-a*a), s(1/10+a*a)]) * sign
+    code = np.stack([coeff@basis0, coeff@basis1], axis=0)
+    ret = code
+    if return_info:
+        su2 = numqi.gate.rz(np.array([2,4,4,6,6,8,8])*np.pi/10)
+        lambda_ai = np.zeros(210, dtype=np.float64)
+        lambda_ai[[65,74,200,209]] = np.array([1,-1,1,-1])/5
+        lambda_ai[[83,182,191]] = np.array([-2,-3,-4])/5
+        lambda_ai[[110,137,146]] = np.array([1,1,-1]) * (2/9 - 16/9*a*a)
+        lambda_ai[101] = -2/90+16/9*a*a
+        lambda_ai[119] = -1/45 - 20/9*a*a
+        lambda_ai[[128,155]] = np.array([1,-1]) * (17/45 - 20/9*a*a)
+        lambda_ai[92] = -8/45 + 20/9*a*a
+        lambda_ai[[29,38]] = np.array([1,-1])*(-0.4 + 4*a*a)
+        lambda_ai[[75,79]] = 2*(-1/9*coeff[3]*coeff[4] - coeff[1]*coeff[2]).real
+        lambda_ai[[156,160]] = -2*np.sqrt(5/63)*(coeff[0]*coeff[4]).real
+        lambda_ai[[201,205]] = 2*np.sqrt(4/63)*(coeff[0]*coeff[4]).real
+        A2 = 1451/675 - 1468/135*a*a + 1520/27*a**4 - 16/9*np.prod(sign[1:])*a*np.sqrt((1/5-a*a)*(7/20-a*a)*(1/10+a*a))
+        # A2 range [1.58?, 2.22?]
+        qweA = np.array([1,0,A2,0,21-2*A2,0,42+A2,0])
+        qweB = np.array([1,0,A2,21+3*A2,21-2*A2,126-6*A2,42+A2,45+3*A2])
+        ret = code, dict(su2=su2, coeff=coeff, basis0=basis0, basis1=basis1, a=a, sign=sign, lambda_ai=lambda_ai, qweA=qweA, qweB=qweB)
+    return ret
+
+
+def get_BD22(a:float, sign=None, return_info=False):
+    assert 0 <= a <= np.sqrt(3/22)
+    if sign is None:
+        sign = np.ones(5, dtype=np.float64)
+    else:
+        sign = tuple(int(x) for x in sign)
+        assert len(sign) == 5
+        assert all(x in [1,-1] for x in sign)
+        sign = np.asarray(sign)
+    s = np.sqrt
+    si = lambda x: np.sqrt(x)*1j
+    basis0 = np.zeros((5, 128), dtype=np.complex128)
+    basis0[0, [0,90,60,35]] = np.array([1,s(2),s(3),2j])/s(10)
+    basis0[[1,2], [13,21]] = 1
+    basis0[3, [78,105]] = np.array([s(5),2])/3
+    basis0[4, [86,113]] = np.array([s(5),-2])/3
+    basis1 = (hf_pauli('X'*7) @ basis0.T).T
+    coeff = np.array([s(5/11), a*1j, si(3/22-a*a), s(3/11-a*a), s(3/22+a*a)]) * sign
+    code = np.stack([coeff@basis0, coeff@basis1], axis=0)
+    ret = code
+    if return_info:
+        su2 = numqi.gate.rz(np.array([2,4,6,6,6,8,10])*np.pi/11)
+        lambda_ai = np.zeros(210, dtype=np.float64)
+        lambda_ai[[29,65,74,110,209]] = np.array([-1,1,-1,-1,-1])*3/11
+        lambda_ai[[101,119,200]] = np.array([-1,1,-1])*5/11
+        lambda_ai[[56,128,191]] = -1/11
+        lambda_ai[[120,124]] = 2*(1/9*coeff[3]*coeff[4] - coeff[1]*coeff[2]).real
+        lambda_ai[[156,160]] = 2/3*(coeff[0]*coeff[4]).real
+        lambda_ai[[129,133]] = 2/3*(coeff[0]*coeff[3]).real
+        lambda_ai[155] = -7/33 - 20/9*a*a
+        lambda_ai[173] = -1/33 - 20/9*a*a
+        lambda_ai[182] = -17/33 + 20/9*a*a
+        lambda_ai[146] = -1/3 + 20/9*a*a
+        lambda_ai[83] = -7/33 + 16/9*a*a
+        lambda_ai[164] = 5/33 + 16/9*a*a
+        lambda_ai[92] = 1/33 - 16/9*a*a
+        lambda_ai[137] = 13/33 - 16/9*a*a
+        lambda_ai[38] = -1/11 + 4*a*a
+        lambda_ai[47] = 5/11 - 4*a*a
+        A2 = 743/363 - 760/99*a*a + 1520/27*a**4 + 16*np.prod(sign[1:])/9*a*np.sqrt((3/11-a*a)*(3/22+a*a)*(3/22-a*a))
+        # A2 range [1.76? 2.047?]
+        qweA = np.array([1,0,A2,0,21-2*A2,0,42+A2,0])
+        qweB = np.array([1,0,A2,21+3*A2,21-2*A2,126-6*A2,42+A2,45+3*A2])
+        ret = code, dict(su2=su2, coeff=coeff, basis0=basis0, basis1=basis1, a=a, sign=sign, lambda_ai=lambda_ai, qweA=qweA, qweB=qweB)
+    return ret
+
+
+def get_BD24(sign:str, return_info:bool=False):
+    assert sign in '+-'
+    sign = 1 if sign=='+' else -1
+    basis0 = np.zeros((2,128), dtype=np.float64)
+    basis0[0, [0,58,92,102]] = np.array([1,1,1,-1])/2
+    basis0[1, [3,5,63,95,105,113]] = np.array([1,-1,1,-1,1,-1])/np.sqrt(6)
+    basis1 = (hf_pauli('X'*7) @ basis0.T).T
+    coeff = np.array([np.sqrt(1/2),sign*np.sqrt(1/2)])
+    code = np.stack([coeff @ basis0, coeff @ basis1], axis=0)
+    ret = code
+    if return_info:
+        qweA = np.array([1, 0, 7/6, 0, 56/3, 0, 259/6, 0])
+        qweB = np.array([1, 0, 7/6, 49/2, 56/3, 119, 259/6, 97/2])
+        su2 = numqi.gate.rz(np.array([1,1,3,3,5,5,7])*2*np.pi/12) #logical rz(pi/6)
+        info = dict(basis0=basis0, basis1=basis1, qweA=qweA, qweB=qweB, su2=su2)
+        ret = code, info
+    return ret
+
+
+def get_BD26(a:float, sign=None, return_info=False):
+    assert 0 <= a <= np.sqrt(2/13)
+    if sign is None:
+        sign = np.ones(5, dtype=np.float64)
+    else:
+        sign = tuple(int(x) for x in sign)
+        assert len(sign) == 5
+        assert all(x in [1,-1] for x in sign)
+        sign = np.asarray(sign)
+    s = np.sqrt
+    si = lambda x: np.sqrt(x)*1j
+    basis0 = np.zeros((5,128), dtype=np.complex128)
+    basis0[0, [0,58,90,102,67]] = np.array([1,2,s(3),s(5),1j])/s(14)
+    basis0[[1,2,3,4], [105,113,13,21]] = np.array([1,1,1,1])
+    basis1 = (hf_pauli('X'*7) @ basis0.T).T
+    coeff = np.array([s(7/13), a, s(max(0,2/13-a*a)), si(3/13-a*a), si(1/13+a*a)]) * sign
+    code = np.stack([coeff@basis0, coeff@basis1], axis=0)
+    ret = code
+    if return_info:
+        su2 = numqi.gate.rz(np.array([4,4,6,6,8,10,12])*np.pi/13)
+        lambda_ai = np.zeros(210, dtype=np.float64)
+        lambda_ai[[29,65,110,119]] = np.array([1,1,1,-1])*5/13
+        lambda_ai[[56,74,101,191,200]] = np.array([-1,-1,-1,-1,1])*3/13
+        lambda_ai[[128,146,155,173,182]] = np.array([1,1,-1,1,-1])/13
+        lambda_ai[209] = -11/13
+        lambda_ai[[21,25]] = np.sqrt(12)/13
+        lambda_ai[[120,124]] = 2*(coeff[1]*coeff[2] - coeff[3]*coeff[4]).real
+        lambda_ai[38] = 1/13 - 4*a*a
+        lambda_ai[83] = 3/13 - 4*a*a
+        lambda_ai[92] = -5/13 + 4*a*a
+        lambda_ai[47] = -7/13 + 4*a*a
+        lambda_ai[137] = -9/13 + 4*a*a
+        lambda_ai[164] = -1/13 - 4*a*a
+        A2 = 485/169 - 160/13*a*a + 80*a**4 + 16*np.prod(sign[1:])*a*np.sqrt((2/13-a*a)*(3/13-a*a)*(1/13+a*a))
+        # A2 range [2.20?, 2.88?]
+        qweA = np.array([1,0,A2,0,21-2*A2,0,42+A2,0])
+        qweB = np.array([1,0,A2,21+3*A2,21-2*A2,126-6*A2,42+A2,45+3*A2])
+        ret = code, dict(su2=su2, coeff=coeff, basis0=basis0, basis1=basis1, a=a, sign=sign, lambda_ai=lambda_ai, qweA=qweA, qweB=qweB)
+    return ret
+
+
+def get_BD28(a:float, sign=None, return_info=False):
+    assert 0 <= a <= np.sqrt(1/14)
+    if sign is None:
+        sign = np.ones(5, dtype=np.float64)
+    else:
+        sign = tuple(int(x) for x in sign)
+        assert len(sign) == 5
+        assert all(x in [1,-1] for x in sign)
+        sign = np.asarray(sign)
+    s = np.sqrt
+    si = lambda x: np.sqrt(x)*1j
+    basis0 = np.zeros((5, 128), dtype=np.complex128)
+    basis0[0, [0,60,90,113,13]] = np.array([1,s(3),s(5),2,s(6)*1j])/s(19)
+    basis0[[1,2,3,4], [86,102,19,35]] = 1
+    basis1 = (hf_pauli('X'*7) @ basis0.T).T
+    coeff = np.array([s(19/28), a, s(5/28-a*a), si(max(0,1/14-a*a)), si(1/14+a*a)]) * sign
+    code = np.stack([coeff@basis0, coeff@basis1], axis=0)
+    ret = code
+    if return_info:
+        su2 = numqi.gate.rz(np.array([4,6,6,8,8,10,12])*np.pi/14)
+        lambda_ai = np.zeros(210, dtype=np.float64)
+        lambda_ai[[47,  56, 164, 173, 191]] = np.array([-1,-1,1,-1,-1])*2/7
+        lambda_ai[[65,  74, 209]] = np.array([3,-3,-3])/7
+        lambda_ai[[128, 182, 200]] = np.array([1,-1,-1])/7
+        lambda_ai[92] = -4/7
+        lambda_ai[[101,119]] = (1/7 - 4*a*a)*np.array([1,-1])
+        lambda_ai[[156,160]] = 2*np.sqrt(5/19)*(coeff[0]*coeff[1]).real
+        lambda_ai[29] = 2/7 - 4*a*a
+        lambda_ai[38] = 2/7 + 4*a*a
+        lambda_ai[137] = 4*a*a - 4/7
+        lambda_ai[155] = -1/7 - 4*a*a
+        lambda_ai[[75,79]] = 2*(coeff[1]*coeff[2] - coeff[3]*coeff[4]).real
+        A2 = 95/49 - 20/7*a*a + 80*a**4 + 16*np.prod(sign[1:])*a*np.sqrt((5/28-a*a)*(1/196-a**4))
+        # A2 range [1.85?, 2.15?]
+        qweA = np.array([1,0,A2,0, 21-2*A2, 0, 42+A2, 0])
+        qweB = np.array([1,0,A2, 21+3*A2, 21-2*A2, 126-6*A2, 42+A2, 45+3*A2])
+        ret = code, dict(su2=su2, coeff=coeff, basis0=basis0, basis1=basis1, a=a, sign=sign, lambda_ai=lambda_ai, qweA=qweA, qweB=qweB)
+    return ret
+
+
+def get_BD30(a:float, sign=None, return_info=False):
+    assert 0 <= a <= np.sqrt(7/30)
+    if sign is None:
+        sign = np.ones(5, dtype=np.float64)
+    else:
+        sign = tuple(int(x) for x in sign)
+        assert len(sign) == 5
+        assert all(x in [1,-1] for x in sign)
+        sign = np.asarray(sign)
+    basis0 = np.zeros((5,128), dtype=np.float64)
+    basis0[0, [0,3,58,90,102]] = np.array([1,1,2,2,np.sqrt(6)])/4
+    basis0[[1,2,3,4], [13,21,105,113]] = 1
+    basis1 = (hf_pauli('X'*7) @ basis0.T).T
+    s = np.sqrt
+    si = lambda x: np.sqrt(x)*1j
+    coeff = np.array([s(8/15), a*1j, si(max(0,3/10-a*a)), s(max(0,7/30-a*a)), s(max(0,a*a-1/15))]) * sign
+    code = np.stack([coeff@basis0, coeff@basis1], axis=0)
+    ret = code
+    if return_info:
+        su2 = numqi.gate.rz(np.array([4,4,6,6,8,14,16])*np.pi/15)
+        lambda_ai = np.zeros(210, dtype=np.float64)
+        lambda_ai[[21,25]] = 4/15
+        lambda_ai[29] = 7/15
+        lambda_ai[[56,101,191,200]] = np.array([-1,-1,-1,1])/5
+        lambda_ai[[65,74,110,119]] = np.array([1,-1,1,-1])/3
+        lambda_ai[[128, 146, 155, 173, 182, 201, 205]] = np.array([1,1,-1,1,-1,1,-1])/15
+        lambda_ai[209] = -13/15
+        lambda_ai[[38,83]] = 4*a*a - 11/15
+        lambda_ai[[47,92]] = 7/15 - 4*a*a
+        lambda_ai[137] = 1/5 - 4*a*a
+        lambda_ai[164] = 4*a*a - 1
+        lambda_ai[[120,124]] = (-2*coeff[1]*coeff[2] + 2*coeff[3]*coeff[4]).real
+        A2 = 313/75 - 24*a*a + 80*a**4 + 16*np.prod(sign[1:])*np.sqrt(a*a*(3/10-a*a)*(7/30-a*a)*(a*a-1/15))
+        # A2 range [2.173? 2.94?]
+        qweA = np.array([1,0,A2,0, 21-2*A2, 0, A2+42, 0])
+        qweB = np.array([1,0,A2, 3*A2+21, 21-2*A2, 126-6*A2, A2+42, 3*A2+45])
+        info = dict(basis0=basis0, basis1=basis1, coeff=coeff, su2=su2, sign=sign, a=a, lambda_ai=lambda_ai, qweA=qweA, qweB=qweB)
+        ret = code, info
+    return ret
+
+
+def get_BD32(a:float, sign=None, return_info=False):
+    # sqrt(T)
+    if sign is None:
+        sign = np.ones(9, dtype=np.float64)
+    else:
+        sign = tuple(int(x) for x in sign)
+        assert len(sign) == 9
+        assert all(x in [1,-1] for x in sign)
+        sign = np.asarray(sign)
+    assert 0<= a <= 1/np.sqrt(8)
+    s = np.sqrt
+    si = lambda x: np.sqrt(x)*1j
+    coeff = np.array([s(1/32), si(a*a+1/16), si(3/16-a*a), si(4/32), s(3/32), s(7/32), s(5/32), s(max(0,1/8-a*a)), a]) * sign
+    basis0 = np.zeros((9, 128), dtype=np.float64)
+    basis0[[0,1,2,3,4,5,6,7,8], [0,13,21,35,60,90,102,105,113]] = 1
+    basis1 = (hf_pauli('X'*7) @ basis0.T).T
+    code = np.stack([coeff@basis0, coeff@basis1], axis=0)
+    if return_info:
+        su2 = numqi.gate.rz(np.array([2,3,4,4,5,6,7])*2*np.pi/16)
+        lambda_ai = np.zeros(210, dtype=np.float64)
+        lambda_ai[[29,110,146,173]] = np.array([1,1,-1,-1])/8
+        lambda_ai[[65,74,209]] = np.array([1,-1,-1])/2
+        lambda_ai[[56,191]] = -3/8
+        lambda_ai[[128, 155, 182]] = np.array([1,-1,-1])/4
+        lambda_ai[[47, 164]] = np.array([1,-1]) * (3/8 - 4*a*a)
+        lambda_ai[[38, 137]] = np.array([-1,1]) * (1/8 - 4*a*a)
+        lambda_ai[92] = -1/8 - 4*a*a
+        lambda_ai[83] = -5/8 + 4*a*a
+        lambda_ai[[120,124]] = 2*(coeff[7]*coeff[8] - coeff[1]*coeff[2]).real
+        A2 = 67/32 -10*a*a + 80*a**4 + 16*np.prod(sign[[1,2,7,8]])*a*np.sqrt((a*a+1/16)*(3/16-a*a)*(1/8-a*a))
+        # A2 range [53/32, 2.1032206?]
+        qweA = np.array([1, 0, A2, 0, 21-2*A2, 0, 42+A2, 0]) #same as 723-cyclic
+        qweB = np.array([1,0,A2,21+3*A2,21-2*A2,126-6*A2,42+A2,45+3*A2])
+        info = dict(su2=su2, basis0=basis0, basis1=basis1, coeff=coeff, a=a, sign=sign, lambda_ai=lambda_ai, A2=A2, qweA=qweA, qweB=qweB)
+        ret = code,info
+    else:
+        ret = code
+    return ret
+
+
+def get_BD34(sign=None, theta=0, return_info=False):
+    if sign is None:
+        sign = np.ones(8, dtype=np.float64)
+    else:
+        sign = tuple(int(x) for x in sign)
+        assert (len(sign)==8) and all([x in [-1, 1] for x in sign])
+    basis0 = np.zeros((8,128), dtype=np.float64)
+    basis0[np.arange(8), [0, 3, 58, 90, 102, 105, 14, 21]] = 1
+    basis1 = (hf_pauli('X'*7) @ basis0.T).T
+    s = np.sqrt
+    si = lambda x: np.sqrt(x)*1j
+    phase = np.array([np.exp(1j*theta)]*2 + [1]*6)
+    coeff = np.array([1,1,2,2,s(6),s(7),si(2),3j])/s(34) * phase * np.asarray(sign)
+    code = np.stack([coeff@basis0, coeff@basis1], axis=0)
+    ret = code
+    if return_info:
+        c2t = np.cos(2*theta)
+        tmp0 = np.array([289,0,831,44,4063,768,12289,212])/289
+        tmp1 = np.array([0,0,0,-44,344,-768,680,-212])/289
+        qweA = tmp0 + tmp1*c2t
+        tmp0 = np.array([289,0,831,8394,5255,29892,14169,15154])/289
+        tmp1 = np.array([0,0,0,168,-848,1536,-1200,344])/289
+        qweB = tmp0 + tmp1*c2t
+        su2 = numqi.gate.rz(np.array([2,2,3,4,5,8,9])*2*np.pi/17)
+        ret = code, dict(basis0=basis0, basis1=basis1, coeff=coeff, su2=su2, qweA=qweA, qweB=qweB, sign=sign, theta=theta)
+    return ret
+
+
+def get_BD36(sign=None, theta:float=0, return_info=False):
+    if sign is None:
+        sign = np.ones(7, dtype=np.float64)
+    else:
+        assert len(sign)==7
+        sign = [int(x) for x in sign]
+        assert all((x==1 or x==-1) for x in sign)
+        sign = np.array([np.exp(1j*theta)] + sign)
+    basis0 = np.zeros((8,128), dtype=np.float64)
+    basis0[np.arange(8),[0,14,60,35,102,105,90,21]] = np.array([1]*8)
+    basis1 = (hf_pauli('X'*7) @ basis0.T).T
+    s = np.sqrt
+    si = lambda x: np.sqrt(x)*1j
+    coeff = np.array([s(1),s(2),si(3),s(4),si(5),si(6),si(7),s(8)])/6 * sign
+    code = np.stack([coeff@basis0, coeff@basis1], axis=0)
+    ret = code
+    if return_info:
+        c2t = np.cos(2*theta)
+        tmp0 = np.array([1,0,161/81,7/81,1330/81,35/27,3472/81,28/81])
+        tmp1 = np.array([0,0,0,7/81,-49/81,35/27,-91/81,28/81])*c2t
+        qweA = tmp0 + tmp1
+        tmp0 = np.array([1,0,161/81,721/27,497/27,3010/27,3731/81,4079/81])
+        tmp1 = np.array([0,0,0,-7/27,112/81,-70/27,56/27,-49/81])*c2t
+        qweB = tmp0 + tmp1
+        su2 = numqi.gate.rz(np.array([40,60,80,100,120,140,160])*np.pi/180)
+        ret = code, dict(basis0=basis0, basis1=basis1, coeff=coeff, su2=su2, qweA=qweA, qweB=qweB, sign=sign, theta=theta)
+    return ret
+
+
+def get_2O_X5(sign=None, return_info:bool=False):
+    if sign is None:
+        sign = np.array([1, -1, 1, 1, -1, 1], dtype=np.int64)
+    else:
+        sign = tuple(int(x) for x in sign)
+        assert len(sign) == 6
+        assert all(x in [1,-1] for x in sign)
+        assert (sign[1]==-sign[0]) and (sign[4]==-sign[0]) and (sign[5]==sign[3])
+        sign = np.asarray(sign, dtype=np.int64)
+    s = np.sqrt
+    basis0 = np.zeros((6,128), dtype=np.float64)
+    basis0[0, [0,15,20,99,108,119,3,12,23,96,111,116]] = np.array([1]*6 + [-1]*6)/np.sqrt(12)
+    basis0[1, [36,40,51,60,68,72,83,92,39,43,48,63,71,75,80,95]] = np.array([1]*8 + [-1]*8)/4
+    basis0[2, [32,35,84,87,52,55,64,67]] = np.array([1]*4 + [-1]*4)/np.sqrt(8)
+    basis0[3, [33,53,66,86,34,54,65,85]] = np.array([1]*4 + [-1]*4)/np.sqrt(8)
+    basis0[4, [24,123,27,120]] = np.array([1,1,-1,-1]) / 2
+    basis0[5, [45,78,46,77]] = np.array([1,1,-1,-1]) / 2
+    basis1 = (hf_pauli('XXXXXII') @ basis0.T).T
+    coeff = np.array([1/4, 1/2, 1/2, s(1/12), s(3)/4, s(1/6)]) * sign
+    code = np.stack([coeff@basis0,coeff@basis1], axis=0)
+    ret = code
+    if return_info:
+        su2X = np.stack([numqi.gate.X]*5 + [numqi.gate.I]*2, axis=0)
+        axis = np.array([[-1,0,-s(3)], [-1,0,-s(3)], [-1,0,1], [1,0,1], [-1,0,-1]])
+        I,X,Y,Z = numqi.gate.I, numqi.gate.X, numqi.gate.Y, numqi.gate.Z
+        theta = np.array([np.pi, np.pi, np.pi/2, np.pi/2, np.pi/2])
+        nx,ny,nz = (axis.T/np.linalg.norm(axis, axis=1)).reshape(3,-1,1,1)
+        tmp0 = np.cos(theta/2).reshape(-1,1,1)*I - 1j*np.sin(theta/2).reshape(-1,1,1)*(X*nx + Y*ny + Z*nz)
+        su2YSY = np.stack(tmp0.tolist() + [I,I], axis=0)
+        qweA = np.array([1,0,1,0,19,0,43,0])
+        qweB = np.array([1,0,1,24,19,120,43,48])
+        info = dict(basis0=basis0, basis1=basis1, coeff=coeff, sign=sign, su2X=su2X, su2YSY=su2YSY, qweA=qweA, qweB=qweB)
+        ret = code, info
+    return ret
+
+

--- a/python/numqi/qec/q823.py
+++ b/python/numqi/qec/q823.py
@@ -1,0 +1,250 @@
+import numpy as np
+import scipy.linalg
+
+import numqi.gate
+
+from ._pauli import hf_pauli
+
+def get_BD38_LP(coeff2=None, sign=None, phase0=None, return_info=True, seed=None):
+    matA = np.array([[1,1,1,1,1,1,1,1,1,1,-1,-1,-1,-1,-1],
+                [1,1,1,1,-1,-1,-1,-1,-1,-1,1,1,-1,-1,-1],
+                [1,-1,-1,-1,1,1,1,-1,-1,-1,1,-1,1,-1,-1],
+                [1,1,1,-1,1,1,-1,1,-1,-1,-1,1,1,1,-1],
+                [1,1,-1,1,1,-1,1,-1,1,-1,-1,1,1,-1,1],
+                [1,1,-1,-1,1,-1,-1,1,1,-1,1,-1,-1,1,1],
+                [1,-1,-1,-1,-1,-1,-1,1,1,1,1,1,1,-1,-1],
+                [1,-1,1,1,-1,1,1,-1,-1,1,-1,-1,-1,1,1],
+                [1,1,1,1,1,1,1,1,1,1,1,1,1,1,1]])
+    vecb = np.array([0]*8+[1])
+    if (coeff2 is None) or (sign is None) or (phase0 is None):
+        np_rng = np.random.default_rng(seed)
+    phase0 = np_rng.uniform(0, 2*np.pi) if phase0 is None else float(phase0)
+    if sign is None:
+        sign = np_rng.integers(2, size=14)*2-1
+    else:
+        sign = tuple(int(x) for x in sign)
+        assert (len(sign)==14) and all(x in [1,-1] for x in sign)
+        sign = np.asarray(sign, dtype=np.int64)
+    phase = np.concatenate([np.exp(1j*phase0).reshape(-1), sign])
+    if coeff2 is not None:
+        assert (coeff2.shape==(15,)) and np.all(coeff2>=0)
+        assert np.abs(matA @ coeff2 - vecb).max() < 1e-10
+        coeff2[0] = 1/38
+        coeff2[10] = 4/19
+    else:
+        matB = scipy.linalg.null_space(matA) #(15,6)
+        x0 = np.array([8, 10, 23, 23, 10, 23, 23, 10, 10, 12, 64, 24, 24, 20, 20])/(19*16)
+        tmp0 = np_rng.normal(size=matB.shape[1])
+        tmp1 = matB @ (tmp0/np.linalg.norm(tmp0))
+        ind0 = tmp1>1e-5
+        ind1 = tmp1 < -1e-5
+        assert np.any(ind0) and np.any(ind1)
+        tmp2 = np_rng.uniform((-x0[ind0]/tmp1[ind0]).max(), (-x0[ind1]/tmp1[ind1]).min())
+        coeff2 = np.maximum(0, x0 + tmp2*tmp1)
+    coeff = np.sqrt(coeff2) * phase
+    basis0 = np.zeros((15, 2**8), dtype=np.complex128)
+    basis0[np.arange(7), [0, 35, 46, 54, 67, 78, 86]] = 1
+    basis0[np.arange(7,15), [105, 113, 124, 153, 165, 197, 234, 242]] = 1j
+    basis1 = (hf_pauli('X'*8) @ basis0.T).T
+    code = np.stack([coeff@basis0,coeff@basis1], axis=0)
+    ret = code
+    if return_info:
+        su2 = numqi.gate.rz(np.array([2,3,3,4,4,5,7,9])*2*np.pi/19)
+        info = dict(su2=su2, coeff=coeff, basis0=basis0, basis1=basis1, coeff2=coeff2, sign=sign, phase0=phase0)
+        ret = code, info
+    return ret
+
+
+def get_BD64(theta, sign, return_info:bool=False):
+    theta = np.asarray(theta, dtype=np.float64)
+    assert theta.shape==(3,)
+    if sign is None:
+        sign = np.array([1]*9, dtype=np.int64)
+    else:
+        sign = tuple(int(x) for x in sign)
+        assert len(sign) == 9
+        assert all(x in [1,-1] for x in sign)
+        sign = np.asarray(sign, dtype=np.int64)
+    s = np.sqrt
+    basis0 = np.zeros((9, 2**8), dtype=np.float64)
+    basis0[np.arange(9), [0,14,35,87,102,105,189,197,218]] = 1
+    basis1 = (hf_pauli('X'*8) @ basis0.T).T
+    coeff = np.array([s(5/32), 1/8*np.exp(1j*theta[2]), s(3/32)*1j, 1/4*1j, s(1/8),
+            s(3/64)*np.exp(1j*theta[0]), s(15/64)*1j, 1/4*np.exp(1j*theta[1]), s(13/64)])*sign
+    code = np.stack([coeff@basis0, coeff@basis1], axis=0)
+    ret = code
+    if return_info:
+        su2 = numqi.gate.rz(np.array([4,7,10,12,17,23,24,30])*2*np.pi/32) #Z(-2pi/32)
+        # TODO weight enumeartor
+        info = dict(theta=theta, sign=sign, basis0=basis0, basis1=basis1, coeff=coeff, su2=su2)
+        ret = code,info
+    return ret
+
+
+def get_BD72(theta=None, sign=None, return_info=True, seed=None):
+    if (theta is None) or (sign is None):
+        np_rng = np.random.default_rng(seed)
+    if theta is None:
+        theta = np_rng.uniform(0, 2*np.pi, size=5)
+    else:
+        assert len(theta)==5
+    if sign is None:
+        sign = np_rng.integers(2, size=3)*2-1
+    else:
+        assert len(sign)==3
+        sign = [int(x) for x in sign]
+        assert all((x==1 or x==-1) for x in sign)
+    hf0 = lambda i: np.exp(1j*theta[i])
+    phase = np.array([1,hf0(0),hf0(1),sign[0]*hf0(1),hf0(2),
+                hf0(3),1j*sign[1]*hf0(1),hf0(4),1j*sign[2]*hf0(0)])
+    coeff = np.sqrt(np.array([1,14,3,13,5,8,10,6,12])/72) * phase
+    basis0 = np.zeros((9, 2**8), dtype=np.complex128)
+    basis0[np.arange(9), [0,13,60,90,102,150,163,236,241]] = 1
+    basis1 = (hf_pauli('XXXXXXXX') @ basis0.T).T
+    code = np.stack([coeff@basis0, coeff@basis1], axis=0)
+    ret = code
+    if return_info:
+        su2 = numqi.gate.rz(np.array([3,5,6,8,10,12,13,14])*2*np.pi/36) #rz(-2*np.pi/38)
+        info = dict(theta=theta, sign=sign, coeff=coeff, basis0=basis0, basis1=basis1, su2=su2)
+        ret = code, info
+    return ret
+
+
+def get_BD74(theta=None, sign=None, return_info=True, seed=None):
+    if (theta is None) or (sign is None):
+        np_rng = np.random.default_rng(seed)
+    if theta is None:
+        theta = np_rng.uniform(0, 2*np.pi, size=4)
+    else:
+        assert len(theta)==4
+    if sign is None:
+        sign = np_rng.integers(2, size=4)*2-1
+    else:
+        assert len(sign)==4
+        sign = [int(x) for x in sign]
+        assert all((x==1 or x==-1) for x in sign)
+    hf0 = lambda i: np.exp(1j*theta[i])
+    phase = np.array([1, hf0(0), hf0(1), sign[0]*hf0(1), hf0(2),
+                       1j*sign[1]*hf0(2), hf0(3), 1j*sign[2]*hf0(1), 1j*sign[3]*hf0(0)])
+    coeff = np.sqrt(np.array([1,12,3,11,10,6,7,8,16])/74) * phase
+    basis0 = np.zeros((9, 2**8), dtype=np.complex128)
+    basis0[np.arange(9), [0,7,60,90,105,142,153,163,244]] = 1
+    basis1 = (hf_pauli('XXXXXXXX') @ basis0.T).T
+    code = np.stack([coeff@basis0, coeff@basis1], axis=0)
+    ret = code
+    if return_info:
+        su2 = numqi.gate.rz(np.array([4,6,7,9,10,11,12,14])*2*np.pi/37) #rz(-2*np.pi/37)
+        info = dict(theta=theta, sign=sign, coeff=coeff, basis0=basis0, basis1=basis1, su2=su2)
+        ret = code, info
+    return ret
+
+
+def get_BD76(theta=None, sign=None, return_info=True, seed=None):
+    if (theta is None) or (sign is None):
+        np_rng = np.random.default_rng(seed)
+    if theta is None:
+        theta = np_rng.uniform(0, 2*np.pi, size=6)
+    else:
+        assert len(theta)==6
+    if sign is None:
+        sign = np_rng.integers(2, size=2)*2-1
+    else:
+        assert len(sign)==2
+        sign = [int(x) for x in sign]
+        assert all((x==1 or x==-1) for x in sign)
+    hf0 = lambda i: np.exp(1j*theta[i])
+    phase = np.array([1,hf0(0),hf0(1),hf0(2),hf0(3),hf0(4),hf0(5),1j*sign[0]*hf0(0),1j*sign[1]*hf0(0)])
+    coeff = np.sqrt(np.array([1,18,4,3,7,5,12,10,16])/76)*phase
+    basis0 = np.zeros((9, 2**8), dtype=np.complex128)
+    basis0[np.arange(9), [0,13,35,60,90,102,150,234,241]] = 1
+    basis1 = (hf_pauli('XXXXXXXX') @ basis0.T).T
+    code = np.stack([coeff@basis0, coeff@basis1], axis=0)
+    ret = code
+    if return_info:
+        su2 = numqi.gate.rz(np.array([2,4,7,9,10,12,15,16])*2*np.pi/38) #rz(-2*np.pi/38)
+        info = dict(theta=theta, sign=sign, coeff=coeff, basis0=basis0, basis1=basis1, su2=su2)
+        ret = code, info
+    return ret
+
+
+def get_BD78(theta=None, sign=None, return_info=True, seed=None):
+    if (theta is None) or (sign is None):
+        np_rng = np.random.default_rng(seed)
+    if theta is None:
+        theta = np_rng.uniform(0, 2*np.pi, size=6)
+    else:
+        assert len(theta)==6
+    if sign is None:
+        sign = np_rng.integers(2, size=2)*2-1
+    else:
+        assert len(sign)==2
+        sign = [int(x) for x in sign]
+        assert all((x==1 or x==-1) for x in sign)
+    hf0 = lambda i: np.exp(1j*theta[i])
+    phase = np.array([1,hf0(0),hf0(1),hf0(2),hf0(3),  1j*sign[0]*hf0(3),hf0(4),1j*sign[1]*hf0(0), hf0(5)])
+    coeff = np.sqrt(np.array([1,16,3,5,14,10,9,12,8])/78) * phase
+    basis0 = np.zeros((9, 2**8), dtype=np.complex128)
+    basis0[np.arange(9), [0,19,60,102,105,142,165,220,242]] = 1
+    basis1 = (hf_pauli('XXXXXXXX') @ basis0.T).T
+    code = np.stack([coeff@basis0, coeff@basis1], axis=0)
+    ret = code
+    if return_info:
+        su2 = numqi.gate.rz(np.array([3,5,8,9,10,12,14,16])*2*np.pi/39) #rz(-2*np.pi/39)
+        info = dict(theta=theta, sign=sign, coeff=coeff, basis0=basis0, basis1=basis1, su2=su2)
+        ret = code, info
+    return ret
+
+
+def get_BD80(theta=None, sign=None, return_info=True, seed=None):
+    if (theta is None) or (sign is None):
+        np_rng = np.random.default_rng(seed)
+    if theta is None:
+        theta = np_rng.uniform(0, 2*np.pi, size=6)
+    else:
+        assert len(theta)==6
+    if sign is None:
+        sign = np_rng.integers(2, size=2)*2-1
+    else:
+        assert len(sign)==2
+        sign = [int(x) for x in sign]
+        assert all((x==1 or x==-1) for x in sign)
+    hf0 = lambda i: np.exp(1j*theta[i])
+    phase = np.array([1,hf0(0),hf0(1),hf0(2),hf0(3),  hf0(4),1j*sign[0]*hf0(2),1j*sign[1]*hf0(2),hf0(5)])
+    coeff = np.sqrt(np.array([1,2,8,18,5, 6,11,15,14])/80)*phase
+    basis0 = np.zeros((9, 2**8), dtype=np.complex128)
+    basis0[np.arange(9), [0,14,21,58,102,105,165,195,220]] = 1
+    basis1 = (hf_pauli('XXXXXXXX') @ basis0.T).T
+    code = np.stack([coeff@basis0, coeff@basis1], axis=0)
+    ret = code
+    if return_info:
+        su2 = numqi.gate.rz(np.array([2,5,6,8,11,14,15,18])*2*np.pi/40) #rz(-2*np.pi/40)
+        info = dict(theta=theta, sign=sign, coeff=coeff, basis0=basis0, basis1=basis1, su2=su2)
+        ret = code, info
+    return ret
+
+
+def get_BD84(theta=None, sign:int=None, return_info=True, seed=None):
+    if (theta is None) or (sign is None):
+        np_rng = np.random.default_rng(seed)
+    if theta is None:
+        theta = np_rng.uniform(0, 2*np.pi, size=7)
+    else:
+        assert len(theta)==7
+    if sign is None:
+        sign = (np_rng.integers(2)*2-1).item()
+    else:
+        sign = int(sign)
+        assert sign in [1, -1]
+    hf0 = lambda i: np.exp(1j*theta[i])
+    phase = np.array([1,hf0(0),hf0(1),hf0(2),hf0(3),  hf0(4),hf0(5),hf0(6),1j*sign*hf0(5)])
+    coeff = np.sqrt(np.array([10,4,2,11,12,3,17,9,16])/84)*phase
+    basis0 = np.zeros((9, 2**8), dtype=np.complex128)
+    basis0[np.arange(9), [0,21,59,90,102,105,143,188,241]] = 1
+    basis1 = (hf_pauli('XXXXXXXX') @ basis0.T).T
+    code = np.stack([coeff@basis0, coeff@basis1], axis=0)
+    ret = code
+    if return_info:
+        su2 = numqi.gate.rz(np.array([4,10,13,18,22,27,34,39])*2*np.pi/42) #rz(-2*np.pi/42)
+        info = dict(theta=theta, sign=sign, coeff=coeff, basis0=basis0, basis1=basis1, su2=su2)
+        ret = code, info
+    return ret

--- a/python/numqi/qec/transversal.py
+++ b/python/numqi/qec/transversal.py
@@ -1,0 +1,296 @@
+import itertools
+import numpy as np
+import torch
+import opt_einsum
+import scipy.optimize
+import cvxpy
+
+import numqi.utils
+import numqi.manifold
+import numqi.gate
+import numqi.optimize
+import numqi.group
+
+a = (1+np.sqrt(5))/2
+b = (np.sqrt(5)-1)/2
+su2_finite_subgroup_gate_dict = {
+    'I': np.eye(2),
+    'X': -1j*np.array([[0,1], [1,0]]),
+    'Y': -1j*np.array([[0,-1j], [1j,0]]),
+    'Z': -1j*np.array([[1,0], [0,-1]]),
+    'H': -1j*np.array([[1,1], [1,-1]])/np.sqrt(2),
+    'S': np.array([[np.exp(-1j*np.pi/4),0], [0,np.exp(1j*np.pi/4)]]),
+    'T': np.array([[np.exp(-1j*np.pi/8),0], [0,np.exp(1j*np.pi/8)]]),
+    'F': np.exp(-1j*np.pi/4)/np.sqrt(2) * np.array([[1,-1j], [1,1j]]), #-1j H @ Z(-pi/2)
+    'Phi': np.array([[a+1j*b,1], [-1,a-1j*b]])/2,
+    'Phi*': np.array([[-b+1j*a,1], [-1,-b-1j*a]])/2,
+    # 'tau60': np.array([[1j*(2+a),1+1j], [-1+1j,-1j*(2+a)]])/np.sqrt(5*a+7),
+}
+
+
+def get_su2_finite_subgroup_generator(key:str):
+    if key=='2T':
+        ret = np.stack([su2_finite_subgroup_gate_dict[x] for x in 'XF'])
+        # ret = np.stack([su2_finite_subgroup_gate_dict[x] for x in 'XZF'])
+    elif key.startswith('2O'): #Clifford
+        if key=='2O':
+            ret = np.stack([su2_finite_subgroup_gate_dict[x] for x in 'SH']) #2 generators are enough
+            # ret = np.stack([su2_finite_subgroup_gate_dict[x] for x in 'SHF'])
+        else:
+            assert key=='2Ox' #X, Ry(pi/4) S Ry(-pi/4)
+            ret = np.stack([su2_finite_subgroup_gate_dict['X'], 0.5*np.array([[np.sqrt(2)-1j,-1j], [-1j,np.sqrt(2)+1j]])])
+    elif key=='2I': #Clifford
+        tmp0 = su2_finite_subgroup_gate_dict['Z'] @ su2_finite_subgroup_gate_dict['Phi']
+        ret = np.stack([su2_finite_subgroup_gate_dict['X'], tmp0], axis=0) #2 generators are enough
+        # ret = np.stack([su2_finite_subgroup_gate_dict[x] for x in ['Y','Phi']]) #2 generators are enough
+        # ret = np.stack([su2_finite_subgroup_gate_dict[x] for x in ['X','Z','F','Phi']])
+    elif key.startswith('C'):
+        n2 = int(key[1:])
+        assert n2%2==0
+        ret = np.array([[np.exp(-2j*np.pi/n2),0], [0,np.exp(2j*np.pi/n2)]]).reshape(1,2,2)
+    elif key.startswith('BD'):
+        n2 = int(key[2:])
+        assert n2%2==0
+        ret = np.stack([
+            su2_finite_subgroup_gate_dict['X'],
+            np.array([[np.exp(-2j*np.pi/n2),0], [0,np.exp(2j*np.pi/n2)]])
+        ])
+    else:
+        raise ValueError(f'invalid transversal group "key={key}"')
+    return ret
+
+
+class SearchTransversalGateModel(torch.nn.Module):
+    def __init__(self, code:np.ndarray, tag_rz:bool=False, tag_phase:bool=False):
+        super().__init__()
+        assert (code.ndim==2) and (code.shape[0]>=2)
+        dimK = code.shape[0]
+        num_qubit = numqi.utils.hf_num_state_to_num_qubit(code.shape[1], kind='exact')
+        self.code = torch.tensor(code.T.copy().reshape([2]*num_qubit+[dimK]), dtype=torch.complex128)
+        if tag_rz:
+            self.theta_rz = torch.nn.Parameter(torch.randn(num_qubit, dtype=torch.float64))
+            self.manifold = None
+        else:
+            self.theta_rz = None
+            self.manifold = numqi.manifold.SpecialOrthogonal(2, batch_size=num_qubit, dtype=torch.complex128)
+        self.eyeK = torch.eye(dimK, dtype=torch.complex128)
+        if tag_phase:
+            self.theta_phase = torch.nn.Parameter(torch.randn(1, dtype=torch.float64))
+
+        N = num_qubit
+        tmp0 = [y for x in range(N) for y in [(2,2), (N+x,x)]]
+        self.contract_expr = opt_einsum.contract_expression(self.code, list(range(N))+[2*N],
+                            self.code.conj().resolve_conj(), list(range(N,2*N))+[2*N+1], *tmp0, [2*N+1,2*N], constants=[0,1])
+        self.target_gate = None
+
+    def set_target_gate(self, x:None|np.ndarray):
+        if x is None:
+            self.target_gate = None
+        else:
+            assert np.abs(x@x.T.conj() - np.eye(self.eyeK.shape[0])).max() < 1e-10
+            self.target_gate = torch.tensor(x, dtype=torch.complex128)
+
+    def forward(self, return_info=False):
+        if self.theta_rz is not None:
+            su2 = numqi.gate.rz(self.theta_rz)
+        else:
+            su2 = self.manifold()
+        logicalU = self.contract_expr(*su2)
+        if self.target_gate is None:
+            tmp0 = (logicalU @ logicalU.T.conj() - self.eyeK).reshape(-1)
+        else:
+            tmp0 = self.target_gate * (torch.exp(1j*self.theta_phase) if hasattr(self,'theta_phase') else 1)
+            tmp0 = (logicalU - tmp0).reshape(-1)
+        ret = torch.vdot(tmp0, tmp0).real
+        if return_info:
+            ret = ret, su2.detach().numpy(), logicalU.detach().numpy()
+        return ret
+
+
+def get_transversal_group(code:np.ndarray, num_round=100, optim_tol=1e-15, tag_print=False, optim_kwargs=None,
+                max_num_logical:int|None=150, zero_eps_same=1e-5, zero_eps_minimize=1e-10):
+    if optim_kwargs is None:
+        optim_kwargs = dict(theta0='uniform', num_repeat=20, tol=1e-10, early_stop_threshold=1e-7, print_every_round=0)
+    hf_is_same = lambda x,y: (np.abs(x - y).max() < zero_eps_same)
+    model = SearchTransversalGateModel(code)
+    logical_list = [] #list of tuple (logicalU,physicalU)
+    for ind0 in range(num_round):
+        theta_optim = numqi.optimize.minimize(model, **optim_kwargs)
+        theta_optim = numqi.optimize.minimize(model, theta0=theta_optim.x, num_repeat=1, tol=optim_tol, print_every_round=0)
+        if theta_optim.fun > zero_eps_minimize:
+            continue
+        with torch.no_grad():
+            loss,physicalU,logicalU = model(return_info=True) # loss, physicalU, logicalU
+            logicalU = logicalU * np.exp(-1j*np.angle(np.linalg.det(logicalU))/2) #not necessary SU(2), e.g., 623-SO5 code
+        if any(hf_is_same(logicalU, x[0]) for x in logical_list):
+            continue
+        logical_list.append((logicalU,physicalU))
+        if tag_print:
+            print(f'[{len(logical_list)}/{ind0+1}/{theta_optim.fun:.5g}]\n{np.around(logicalU,3)}')
+    # complete group, almost the same as numqi.group.get_complete_group
+    check_list = [(x,y) for x in range(len(logical_list)) for y in range(len(logical_list))]
+    # TODO replace with np.append
+    while len(check_list):
+        ind0,ind1 = check_list.pop(0)
+        np1 = logical_list[ind0][0] @ logical_list[ind1][0]
+        if not any(hf_is_same(np1, x[0]) for x in logical_list):
+            np2 = logical_list[ind0][1] @ logical_list[ind1][1]
+            logical_list.append((np1,np2))
+            check_list += [(x,len(logical_list)-1) for x in range(len(logical_list))]
+            check_list += [(len(logical_list)-1,x) for x in range(len(logical_list))]
+        if (max_num_logical is not None) and len(logical_list)>=max_num_logical: #numerical is not stable
+            break
+    return logical_list
+
+
+def get_transversal_group_info(np_list, tag_print=True, zero_eps=1e-7):
+    np_list = np.stack(np_list, axis=0)
+    assert (np_list.ndim==3) and (np_list.shape[1]==np_list.shape[2])
+    N0 = np_list.shape[1]
+    cayley_table = np.zeros((len(np_list), len(np_list)), dtype=np.int64)
+    for ind0 in range(len(np_list)):
+        tmp0 = (np_list[ind0] @ np_list).reshape(-1,1,N0*N0)
+        tmp1 = np.abs(tmp0 - np_list.reshape(-1,N0*N0)).max(axis=2) < zero_eps
+        assert np.all(tmp1.sum(axis=0)==1) and np.all(tmp1.sum(axis=1)==1)
+        cayley_table[ind0] = tmp1.nonzero()[1]
+    left_regular_form = numqi.group.cayley_table_to_left_regular_form(cayley_table) #(np,int,(N0,N0,N0))
+    irrep_list = numqi.group.reduce_group_representation(left_regular_form, tagI=True) #(list,(np,complex,(N0,N1,N1)))
+    _,class_list,character_table = numqi.group.get_character_and_class(irrep_list, tagIFirst=True)
+    ret = {
+        'cayley_table': cayley_table,
+        'irrep_list': irrep_list,
+        'class_list': class_list,
+        'character_table': character_table,
+        'dim_irrep': np.array([x.shape[1] for x in irrep_list], dtype=np.int64),
+        'num_class': np.array([len(x) for x in class_list], dtype=np.int64),
+    }
+    if tag_print:
+        print('order(group):', np_list.shape[0])
+        print('dim(irrep):', ret['dim_irrep'])
+        print('class:', ret["num_class"])
+    return ret
+
+
+def pick_indenpendent_vector(np0:np.ndarray, tag_pure_imag:bool=False, zero_eps:float=1e-10):
+    assert np0.ndim==2
+    if tag_pure_imag:
+        ind0 = np.abs(np0.real).max(axis=1) > zero_eps
+        ind1 = np.abs(np0.imag).max(axis=1) > zero_eps
+        assert np.all((ind0.astype(np.int64) + ind1.astype(np.int64))<2)
+        np0[ind1] = np0[ind1].imag
+        np0 = np0.real
+    np0 = np0[np.abs(np0).max(axis=1) > zero_eps]
+    rank = (np.linalg.svd(np0, compute_uv=False) > zero_eps).sum()
+    if rank==1:
+        ret = np0[0]
+    else:
+        ind0 = [0]
+        while len(ind0)<rank:
+            for x in range(ind0[-1]+1, np0.shape[0]):
+                if np.linalg.svd(np0[ind0 + [x]], compute_uv=False)[-1] > zero_eps:
+                    ind0.append(x)
+                    break
+        ret = np0[ind0]
+    return ret
+
+
+def get_chebshev_center_Axb(A, b, C=None, d=None):
+    # https://en.wikipedia.org/wiki/Chebyshev_center
+    m,n = A.shape
+    if C is None:
+        assert d is None
+        C = -np.eye(n)
+        d = np.zeros(n)
+    cvxX = cvxpy.Variable(n)
+    cvxR = cvxpy.Variable(1)
+    constraint = [
+        A @ cvxX==b,
+        C @ cvxX + np.linalg.norm(C, axis=1)*cvxR <= d,
+    ]
+    obj = cvxpy.Maximize(cvxR)
+    prob = cvxpy.Problem(obj, constraint)
+    prob.solve()
+    ret = cvxX.value, cvxR.value
+    return ret
+
+
+def get_BD2m_submultiset(m:int, veca:np.ndarray):
+    veca = np.asarray(veca, dtype=np.int64)
+    assert len(veca)<=15, 'veca cannot be longer than 15'
+    assert np.all(veca[:-1]<=veca[1:])
+    ind0 = np.array(list(itertools.product([0,1], repeat=len(veca))), dtype=np.int64)
+    ind1 = np.nonzero((ind0 @ veca)%m==0)[0]
+    return ind1
+
+
+def get_C2m_submultiset(m:int, veca:np.ndarray):
+    veca = np.asarray(veca, dtype=np.int64)
+    assert len(veca)<=15, 'veca cannot be longer than 15'
+    assert np.all(veca[:-1]<=veca[1:])
+    ind0 = np.array(list(itertools.product([0,1], repeat=len(veca))), dtype=np.int64)
+    ind1 = np.nonzero((ind0 @ veca)%m==0)[0]
+    ind2 = np.nonzero(((ind0 @ veca)+1)%m==0)[0]
+    return ind1,ind2
+
+
+def _BD_group_LP(bsi:np.ndarray):
+    s,n = bsi.shape
+    tmp0 = np.concatenate([bsi.T, np.ones((1, s))], axis=0)
+    tmp1 = np.ones(n+1)
+    tmp1[:-1] *= 0.5
+    tmp2 = [(0, 1)]*s
+    res = scipy.optimize.linprog(np.zeros(s), A_eq=tmp0, b_eq=tmp1, bounds=tmp2, options={'disp': False})
+    return (res.success and res.status == 0)
+
+def search_veca_BD_group(n:int, m:int, tag_print=True, min_value:int=0, k:int|None=2, min_term=None):
+    if min_term is None:
+        min_term = n
+    assert min_term>=2
+    ind0 = np.array(list(itertools.product([0,1], repeat=n)), dtype=np.int32)
+    if k is None:
+        tmp0 = (x for x in itertools.combinations_with_replacement(range(min_value, m), n) if (sum(x)+1)%m==0)
+    else:
+        assert k>=2
+        tmp0 = (x for x in itertools.combinations_with_replacement(range(min_value, m), n) if sum(x)==(k*m-1))
+    ret = []
+    for a in tmp0:
+        ind1 = (ind0 @ np.array(a))%m==0
+        if (ind1.sum()>=min_term) and _BD_group_LP(ind0[ind1]): #TODO, this results requires bsi has rank n
+            ret.append(a)
+            if tag_print:
+                print(a)
+    return ret
+
+def _C_group_LP(bsi0, bsij0, bsi1, bsij1):
+    s,n = bsi0.shape
+    s1,_ = bsi1.shape
+    tmp0 = np.concatenate([bsi0.T, -bsi1.T], axis=1)
+    tmp0b = np.zeros(n)
+    tmp1 = np.concatenate([bsij0.T, -bsij1.T], axis=1)
+    tmp1b = np.zeros(bsij0.shape[1])
+    tmp2 = np.stack([np.concatenate([np.ones(s),np.zeros(s1)], axis=0), np.concatenate([np.zeros(s),np.ones(s1)], axis=0)], axis=0)
+    tmp2b = np.ones(2)
+    tmp3 = np.concatenate([tmp0, tmp1, tmp2], axis=0)
+    tmp3b = np.concatenate([tmp0b, tmp1b, tmp2b], axis=0)
+    tmp4 = [(0,1)]*(s+s1)
+    res = scipy.optimize.linprog(np.zeros(s+s1), A_eq=tmp3, b_eq=tmp3b, bounds=tmp4, method='highs', options={'disp': False, 'presolve':True})
+    return (res.success and res.status == 0)
+
+
+def search_veca_C_group(n:int, m:int, tag_print=True, min_value:int=0, min_term=None):
+    if min_term is None:
+        min_term = n
+    assert min_term>=2
+    ind0 = np.array(list(itertools.product([0,1], repeat=n)), dtype=np.int32)
+    i0,i1 = np.triu_indices(n,1)
+    ind0ij = ind0[:,i0]*ind0[:,i1]
+    ret = []
+    for a in itertools.combinations_with_replacement(range(min_value, m), n):
+        tmp0 = (ind0 @ np.array(a, dtype=np.int32))%m
+        ind1 = tmp0==0
+        ind2 = tmp0==(m-1)
+        if (ind1.sum() >= min_term) and (ind2.sum() >= min_term) and _C_group_LP(ind0[ind1], ind0ij[ind1], ind0[ind2], ind0ij[ind2]):
+            ret.append(tuple(a))
+            if tag_print:
+                print(a)
+    return ret

--- a/python/numqi/unique_determine/_recovery.py
+++ b/python/numqi/unique_determine/_recovery.py
@@ -26,7 +26,7 @@ class FindStateWithOpModel(torch.nn.Module):
             self.manifold = numqi.manifold.Sphere(op_list.shape[1], dtype=self.cdtype)
         self.op_list = torch.tensor(op_list, dtype=self.cdtype)
         self.expectation = None
-        self.state = None
+        self.state:None|torch.Tensor = None
 
     def set_expectation(self, x:np.ndarray):
         r'''set the expectation values of the operators

--- a/python/numqi/unique_determine/_uda_udp.py
+++ b/python/numqi/unique_determine/_uda_udp.py
@@ -334,8 +334,7 @@ def find_optimal_UD(kind:str, num_round:int, mat_list:np.ndarray|list, num_repea
     else:
         # https://github.com/pytorch/pytorch/wiki/Autograd-and-Fork
         with concurrent.futures.ProcessPoolExecutor(max_workers=num_worker, mp_context=multiprocessing.get_context('spawn')) as executor:
-
-            job_list = [executor.submit(_find_optimal_UD_one, **kwargs, np_rng=x) for x in range(np_rng.spawn(num_round))]
+            job_list = [executor.submit(_find_optimal_UD_one, **kwargs, np_rng=x) for x in np_rng.spawn(num_round)]
             time_start = time.time()
             for ind0,job_i in enumerate(concurrent.futures.as_completed(job_list)):
                 ret_i = job_i.result()

--- a/tests/test_qec/test_gf4.py
+++ b/tests/test_qec/test_gf4.py
@@ -1,0 +1,16 @@
+import numpy as np
+import galois
+import numqi
+
+def test_get_logical_from_stab():
+    stab_str_list = [
+        'XIIIZII IXIIZII IIXIIZI IIIXIIZ IIZZIYY ZZZIXXZ', #bare 7-qubit code
+        'ZZIZIIZ ZIZZIZI IYYYYII IIIZZZZ YYIIYYI YIYIYIY', #steane
+        'XXXXXXXX ZZZZZZZZ IXIXYZYZ IXZYIXZY IYXZXZIY', #((8,8,3))
+    ]
+    for stab_str in stab_str_list:
+        stab = galois.GF2(numqi.qec.str_to_gf4(stab_str.split(' ')))
+        logicalX, logicalZ = numqi.qec.get_logical_from_stabilizer(stab)
+        assert np.all(numqi.qec.matmul_gf4(logicalX, logicalZ.T)==np.eye(len(logicalX), dtype=np.uint8))
+        assert np.all(numqi.qec.matmul_gf4(logicalX, stab.T)==0)
+        assert np.all(numqi.qec.matmul_gf4(logicalZ, stab.T)==0)

--- a/tests/test_qec/test_picode.py
+++ b/tests/test_qec/test_picode.py
@@ -1,0 +1,160 @@
+import numpy as np
+
+import numqi
+
+def test_permutation713code_beth():
+    s = np.sqrt
+    tmp0 = np.array([s(15), 0, -s(7), 0, s(21), 0, s(21), 0])/8
+    # tmp0 = np.array([s(15), s(7), s(21), -s(21)])/8
+    coeff = np.stack([tmp0, tmp0[::-1]], axis=1)
+    Taij,factor_list,pauli_str_list,weight_count = numqi.dicke.get_qubit_dicke_rdm_pauli_tensor(7, 2, kind='scipy-csr01')
+    lambda_aij = coeff.T.conj() @ (Taij @ coeff).reshape(-1, coeff.shape[0], coeff.shape[1])
+    assert np.abs(lambda_aij[:,0,1]).max() < 1e-12
+    assert np.abs(lambda_aij[:,1,0]).max() < 1e-12
+    assert np.abs(lambda_aij[:,0,0].imag).max() < 1e-12
+    assert np.abs(lambda_aij[:,0,0] - lambda_aij[:,1,1]).max() < 1e-12
+    assert abs(np.dot(lambda_aij[:,0,0].real**2, factor_list) - 7) < 1e-10
+
+    np1 = coeff.T.conj() @ numqi.dicke.u2_to_dicke(numqi.gate.X, 7) @ coeff
+    assert np.abs(np1-numqi.gate.X).max() < 1e-10
+    np1 = coeff.T.conj() @ numqi.dicke.u2_to_dicke(numqi.gate.Z, 7) @ coeff
+    assert np.abs(np1-numqi.gate.Z).max() < 1e-10
+    np0 = numqi.gate.H @ numqi.gate.rz(-np.pi/2)
+    np1 = coeff.T.conj() @ numqi.dicke.u2_to_dicke(np0, 7) @ coeff
+    assert np.abs(np1-np0.conj()).max() < 1e-10
+    a = (1+np.sqrt(5))/2
+    b = (1-np.sqrt(5))/2 #a*b=-1
+    np0 = np.array([[b + 1j/b, 1], [-1, b - 1j/b]])/2
+    np1 = coeff.T.conj() @ numqi.dicke.u2_to_dicke(np0, 7) @ coeff
+    logicalU = np.array([[a - 1j/a, 1], [-1, a + 1j/a]])/2
+    assert np.abs(np1 - logicalU).max() < 1e-10
+
+    a = (1+np.sqrt(5))/2
+    b = (1-np.sqrt(5))/2 #a*b=-1
+    np0 = np.array([[b - 1j/b, 1], [-1, b + 1j/b]])/2
+    np1 = coeff.T.conj() @ numqi.dicke.u2_to_dicke(np0, 7) @ coeff
+    logicalU = np.array([[a + 1j/a, 1], [-1, a - 1j/a]])/2
+    assert np.abs(np1 - logicalU).max() < 1e-10
+
+    # tmp0 = np.array([s(15), 0, -s(7), 0, s(21), 0, s(21), 0])/8
+    tmp0 = np.array([s(15), 0, s(7), 0, s(21), 0, -s(21), 0])/8
+    # tmp0 = np.array([s(15), s(7), s(21), -s(21)])/8
+    coeff = np.stack([tmp0, tmp0[::-1]], axis=1)
+    np0 = np.array([[a + 1j/a, 1], [-1, a - 1j/a]])/2
+    np1 = coeff.T.conj() @ numqi.dicke.u2_to_dicke(np0, 7) @ coeff
+    logicalU = np.array([[b - 1j/b, 1], [-1, b + 1j/b]])/2
+    assert np.abs(np1 - logicalU).max() < 1e-10
+
+    code,info = numqi.qec.get_code_subspace('723permutation', sign='-')
+    basis = numqi.dicke.get_dicke_basis(7, dim=2)
+    coeff = code @ basis.T.conj()
+    assert np.abs(coeff.conj() @ coeff.T - np.eye(2)).max() < 1e-10
+    # X Z F Phi
+    np1 = coeff.conj() @ numqi.dicke.u2_to_dicke(numqi.gate.X, 7) @ coeff.T
+    assert np.abs(np1-numqi.gate.X).max() < 1e-10
+    np1 = -coeff.conj() @ numqi.dicke.u2_to_dicke(numqi.gate.Z, 7) @ coeff.T
+    assert np.abs(np1-numqi.gate.Z).max() < 1e-10
+    np0 = numqi.qec.su2_finite_subgroup_gate_dict['F']
+    np1 = 1j * (coeff.conj() @ numqi.dicke.u2_to_dicke(numqi.gate.Z @ np0.conj(), 7) @ coeff.T)
+    assert np.abs(np0-np1).max() < 1e-10
+    np0 = numqi.qec.su2_finite_subgroup_gate_dict['Phi*']
+    np1 = coeff.conj() @ numqi.dicke.u2_to_dicke(numqi.qec.su2_finite_subgroup_gate_dict['Phi'].T.conj(), 7) @ coeff.T
+    assert np.abs(np0-np1).max() < 1e-10
+
+
+def test_permutation713code_q212():
+    # https://arxiv.org/pdf/2310.05358 eq(14) even-odd code
+    # transversal group 2I
+    s = np.sqrt
+    tmp0 = np.array([s(3/10),0,0,0,0,1j*s(7/10),0,0])
+    tmp1 = np.array([0,0,1j*s(7/10),0,0,0,0,s(3/10)])
+    coeff = np.stack([tmp0, tmp1], axis=1)
+    Taij = numqi.dicke.get_qubit_dicke_rdm_pauli_tensor(7, 2, kind='scipy-csr01')[0]
+    lambda_aij = coeff.T.conj() @ (Taij @ coeff).reshape(-1, coeff.shape[0], coeff.shape[1])
+    assert np.abs(lambda_aij[:,0,1]).max() < 1e-12
+    assert np.abs(lambda_aij[:,1,0]).max() < 1e-12
+    assert np.abs(lambda_aij[:,0,0].imag).max() < 1e-12
+    assert np.abs(lambda_aij[:,0,0] - lambda_aij[:,1,1]).max() < 1e-12
+
+    np1 = coeff.T.conj() @ numqi.dicke.u2_to_dicke(numqi.gate.X, 7) @ coeff
+    assert np.abs(np1 - numqi.gate.X).max() < 1e-10
+    np0 = numqi.gate.rz(6*np.pi/5)
+    np1 = coeff.T.conj() @ numqi.dicke.u2_to_dicke(np0, 7) @ coeff
+    assert np.abs(np1 - numqi.gate.rz(2*np.pi/5)).max() < 1e-10
+    I,X,Y,Z = numqi.gate.I, numqi.gate.X, numqi.gate.Y, numqi.gate.Z
+    hfR = lambda a,b,t=1: I*np.cos(t*np.pi/5) + 1j*np.sin(t*np.pi/5)/np.sqrt(5) * (a*Y + b*Z)
+    np0 = coeff.T.conj() @ numqi.dicke.u2_to_dicke(hfR(-2,-1,3), 7) @ coeff
+    assert np.abs(hfR(-2,1) - np0).max() < 1e-10
+
+
+def test_permutation_11_1_3code():
+    s = np.sqrt
+    # https://arxiv.org/abs/2411.13142 eq(2)
+    tmp0 = np.array([s(5),0,0,0,0,0,0,0,s(11),0,0,0])/4
+    tmp1 = np.array([0,0,0,s(11),0,0,0,0,0,0,0,s(5)])/4
+    coeff = np.stack([tmp0, tmp1], axis=1)
+    Taij = numqi.dicke.get_qubit_dicke_rdm_pauli_tensor(11, 2, kind='scipy-csr01')[0]
+    lambda_aij = coeff.T.conj() @ (Taij @ coeff).reshape(-1, coeff.shape[0], coeff.shape[1])
+    assert np.abs(lambda_aij[:,0,1]).max() < 1e-12
+    assert np.abs(lambda_aij[:,1,0]).max() < 1e-12
+    assert np.abs(lambda_aij[:,0,0].imag).max() < 1e-12
+    assert np.abs(lambda_aij[:,0,0] - lambda_aij[:,1,1]).max() < 1e-12
+
+    # transversal gate
+    np0 = numqi.gate.rz(3*np.pi/4)
+    np1 = coeff.T.conj() @ numqi.dicke.u2_to_dicke(np0, 11) @ coeff
+    assert np.abs(numqi.gate.rz(np.pi/4) - np1).max() < 1e-12
+    np0 = numqi.gate.rz(np.pi/4)
+    np1 = coeff.T.conj() @ numqi.dicke.u2_to_dicke(np0, 11) @ coeff
+    assert np.abs(numqi.gate.rz(3*np.pi/4) + np1).max() < 1e-12
+    np1 = coeff.T.conj() @ numqi.dicke.u2_to_dicke(numqi.gate.X, 11) @ coeff
+    assert np.abs(np1-numqi.gate.X).max() < 1e-10
+    np1 = coeff.T.conj() @ numqi.dicke.u2_to_dicke(numqi.gate.Z, 11) @ coeff
+    assert np.abs(np1-numqi.gate.Z).max() < 1e-10
+
+
+def test_get_bg_picode():
+    for b2,g in [(6,3),(7,3),(8,3),(9,3),(10,3)]:
+        # if b2>=g+3 and g>=3, then at least d>=3
+        assert (b2>=g+3) and (g>=3)
+        coeff = numqi.qec.get_bg_picode(b2,g)
+        Taij = numqi.dicke.get_qubit_dicke_rdm_pauli_tensor(coeff.shape[0]-1, 2, kind='scipy-csr01')[0]
+        lambda_aij = coeff.T.conj() @ (Taij @ coeff).reshape(-1, coeff.shape[0], coeff.shape[1])
+        assert np.abs(lambda_aij[:,0,1]).max() < 1e-12
+        assert np.abs(lambda_aij[:,1,0]).max() < 1e-12
+        assert np.abs(lambda_aij[:,0,0].imag).max() < 1e-12
+        assert np.abs(lambda_aij[:,0,0] - lambda_aij[:,1,1]).max() < 1e-12
+
+        if b2%2==0:
+            np0 = coeff.T.conj() @ numqi.dicke.u2_to_dicke(numqi.gate.rz(2*np.pi/b2), coeff.shape[0]-1) @ coeff
+            np1 = numqi.gate.rz(2*np.pi*g/b2)
+            assert np.abs(np0+np1).max() < 1e-10
+
+
+def test_723permutation_code():
+    for sign in '+-':
+        code,info = numqi.qec.get_code_subspace('723permutation', sign=sign)
+        op_list = numqi.qec.make_pauli_error_list_sparse(num_qubit=7, distance=3, kind='scipy-csr01')[1]
+        z0 = code.conj() @ (op_list @ code.T).reshape(-1, 2**7, 2)
+        assert np.abs(z0[:,0,1]).max() < 1e-12
+        tmp0 = np.array([2/3]*18 + [1] + [3]*3)
+        ind0 = [21, 25, 29, 30, 34, 38, 39, 43, 47, 48, 52, 56, 57, 61, 65, 66, 70, 74, 75, 79, 83,
+                84, 88, 92, 93, 97, 101, 102, 106, 110, 111, 115, 119, 120, 124, 128, 129, 133, 137,
+                138, 142, 146, 147, 151, 155, 156, 160, 164, 165, 169, 173, 174, 178, 182, 183, 187,
+                191, 192, 196, 200, 201, 205, 209]
+        tmp0 = np.zeros(210, dtype=np.float64)
+        tmp0[ind0] = 1/3
+        assert np.abs(z0[:,0,0]-tmp0).max() < 1e-10
+
+
+def test_723permutation_code_local_unitary_equivalent():
+    codep,info = numqi.qec.get_code_subspace('723permutation', sign='+')
+    codem,info = numqi.qec.get_code_subspace('723permutation', sign='-')
+    model = numqi.qec.QECCEqualModel(codep, codem)
+    # theta0 = numqi.optimize.minimize(model, 'uniform', num_repeat=10, tol=1e-24).x
+    theta0 = np.array([-0.9851071268903094, 0.9851071309835814, -0.9851071080929052, 0.8286922424445572, -0.8286922385150921,
+            0.8286922425522644, 0.8286922410131242, -0.8286922420980595, 0.8286922443320521, 0.8286922422542674, -0.8286922398812964,
+            0.8286922415662342, -0.9851071239082392, 0.9851071216442577, -0.9851071202221557, -0.9851071170253412, 0.9851071293328815,
+            -0.9851071218120353, -0.9851071289119772, 0.9851071116144996, -0.985107125489987])
+    numqi.optimize.set_model_flat_parameter(model, theta0)
+    assert abs(model().item()) < 1e-12

--- a/tests/test_qec/test_q523.py
+++ b/tests/test_qec/test_q523.py
@@ -1,0 +1,146 @@
+import functools
+import numpy as np
+import scipy.linalg
+import numqi
+
+np_rng = np.random.default_rng()
+hf_kron = lambda *x: functools.reduce(np.kron, x)
+
+
+def test_get_code_subspace_523():
+    code,info = numqi.qec.get_code_subspace('523')
+    # https://arxiv.org/abs/quant-ph/9610040
+    weightA, weightB = numqi.qec.get_weight_enumerator(code, use_circuit=True)
+    weightA_ = np.array([1,0,0,0,15,0])
+    weightB_ = np.array([1,0,0,30,15,18])
+    assert np.abs(weightA-weightA_).max() < 1e-10
+    assert np.abs(weightB-weightB_).max() < 1e-10
+
+    # https://arxiv.org/abs/2204.03560 (eq132)
+    op_list = numqi.qec.make_pauli_error_list_sparse(num_qubit=6, distance=3, kind='numpy')[1]
+    code623 = np.stack([code,code*0], axis=2).reshape(2,-1)
+    # weightA = [1,1,0,0,15,15,0]; weightB = [1,1,0,30,45,33,18]
+    matU = numqi.random.rand_haar_unitary(2)
+    tmp0 = scipy.linalg.block_diag(np.eye(2), matU)
+    code623a = np.einsum(code623.reshape(-1,4), [0,1], tmp0, [3,1], [0,3], optimize=True).reshape(2,-1)
+    tmp1 = code623.reshape(-1, 4)
+    tmp2 = np.concatenate([tmp1[:,:2], tmp1[:,2:] @ matU.T], axis=1).reshape(2, -1)
+    assert np.abs(tmp2 - code623a).max() < 1e-12
+    z0 = code623a.conj() @ (op_list @ code623a.T)
+    assert np.abs(z0[:,0,1]).max() < 1e-12
+    assert np.abs(z0[:,0,0] - z0[:,1,1]).max() < 1e-12
+    assert abs(np.linalg.norm(z0[:,0,0].real)-1) < 1e-10
+
+
+def test_get_transversal_group_523():
+    code,info = numqi.qec.get_code_subspace('523')
+    logical_list = numqi.qec.get_transversal_group(code, num_round=30) #30 should be enough
+    assert len(logical_list)==24 #2T
+    tmp0 = [-numqi.gate.X]*5
+    np1 = code.conj() @ hf_kron(*tmp0) @ code.T
+    assert np.abs(np1 - numqi.gate.X).max() < 1e-10
+    tmp0 = [numqi.gate.Z]*5
+    np1 = code.conj() @ hf_kron(*tmp0) @ code.T
+    assert np.abs(np1 - numqi.gate.Z).max() < 1e-10
+    F = numqi.gate.H @ numqi.gate.rz(-np.pi/2)
+    tmp0 = [numqi.gate.Z @ numqi.gate.X @ F]*5 #F
+    np1 = code.conj() @ hf_kron(*tmp0) @ code.T
+    assert np.abs(np1 - F).max() < 1e-10
+
+    code1 = np.stack([code,code*0], axis=2).reshape(2,-1)
+    code2 = (code1.reshape(-1,4) @ numqi.random.rand_haar_unitary(4)).reshape(2,-1)
+    error_str,error_scipy = numqi.qec.make_pauli_error_list_sparse(6, distance=3, kind='scipy-csr01')
+    z0 = code2.conj() @ (error_scipy @ code2.T).reshape(-1,64,2)
+    assert np.abs(z0[:,0,1]).max() < 1e-10
+    assert np.abs(z0[:,1,0]).max() < 1e-10
+    assert np.abs(z0[:,0,0].imag).max() < 1e-10
+    assert np.abs(z0[:,0,0]-z0[:,1,1]).max() < 1e-10
+    logical_list = numqi.qec.get_transversal_group(code2, num_round=30) #30 should be enough
+    assert len(logical_list)==8 #BD4
+
+    ## slow
+    # code,info = numqi.qec.get_code_subspace('723cyclic', lambda2=4.875)
+    # logical_list = numqi.qec.get_transversal_group(code, num_round=60)
+    # assert len(logical_list)==24 #2T
+
+    # code,info = numqi.qec.get_code_subspace('steane')
+    # logical_list = numqi.qec.get_transversal_group(code, num_round=60)
+    # assert len(logical_list)==48 #2O
+
+
+def test_523u4_623_2T():
+    code523,_ = numqi.qec.get_code_subspace('523')
+    theta = np_rng.uniform(0, np.pi/4)
+    a = np.sqrt((3-np.sqrt(3))/12)
+    b = np.sqrt((3+np.sqrt(3))/6)
+    u2 = 1j*(a*numqi.gate.X + a*numqi.gate.Y - b*numqi.gate.Z)
+    u4 = numqi.gate.CZ @ np.kron(u2, numqi.gate.I)
+    tmp0 = np.array([np.cos(theta), np.sin(theta)]) #numqi.gate.ry(theta*2)
+    code = ((code523.reshape(-1,1) * tmp0).reshape(-1, 4) @ u4.T).reshape(2,-1)
+    error_str,error_scipy = numqi.qec.make_pauli_error_list_sparse(6, distance=3, kind='scipy-csr01')
+    z0 = code.conj() @ (error_scipy @ code.T).reshape(-1,64,2)
+    assert np.abs(z0[:,0,1]).max() < 1e-10
+    assert np.abs(z0[:,1,0]).max() < 1e-10
+    assert np.abs(z0[:,0,0]-z0[:,1,1]).max() < 1e-10
+    A1 = np.linalg.norm(z0[:18,0,0].real)**2
+    A2 = np.linalg.norm(z0[18:,0,0].real)**2
+    assert abs(np.cos(2*theta)**2 - A1) < 1e-10
+    assert abs(np.sin(2*theta)**2 - A2) < 1e-10
+    # A1=0: [1,0,1,0,11,16,3]
+    # numqi.qec.get_code_subspace('623-SO5', vece=np.array([1,0,0,0,0]))[1]['qweA']
+
+    # transversal X, Z, F
+    I,X,Y,Z = numqi.gate.I, numqi.gate.X, numqi.gate.Y, numqi.gate.Z
+    F = numqi.gate.H @ numqi.gate.rz(-np.pi/2)
+    tmp0 = [X,I,Y,Y,I,I]
+    np1 = code.conj() @ hf_kron(*tmp0) @ code.T
+    assert np.abs(np1 - numqi.gate.X).max() < 1e-10
+    tmp0 = [-Y,Z,Y,I,I,I]
+    np1 = code.conj() @ hf_kron(*tmp0) @ code.T
+    assert np.abs(np1 - numqi.gate.Z).max() < 1e-10
+    tmp0 = [1j*Y@F, Y@F, Y@F, Y@F, numqi.gate.rz(2*np.pi/3), I]
+    np1 = code.conj() @ hf_kron(*tmp0) @ code.T
+    assert np.abs(np1 - F).max() < 1e-10
+
+
+def test_523u4_623_BD4():
+    code523,_ = numqi.qec.get_code_subspace('523')
+    theta = np_rng.uniform(0, np.pi/4)
+    error_str,error_scipy = numqi.qec.make_pauli_error_list_sparse(6, distance=3, kind='scipy-csr01')
+    tmp0 = np.array([np.cos(theta), np.sin(theta)])
+    code = ((code523.reshape(-1,1) * tmp0).reshape(-1, 4) @ numqi.gate.CZ.T).reshape(2,-1)
+    z0 = code.conj() @ (error_scipy @ code.T).reshape(-1,64,2)
+    assert np.abs(z0[:,0,1]).max() < 1e-10
+    assert np.abs(z0[:,1,0]).max() < 1e-10
+    assert np.abs(z0[:,0,0]-z0[:,1,1]).max() < 1e-10
+    A1 = np.linalg.norm(z0[:18,0,0].real)**2
+    A2 = np.linalg.norm(z0[18:,0,0].real)**2
+    # TODO formula for higher weight enumerator
+    assert abs(np.cos(2*theta)**2 - A1) < 1e-10
+    assert abs(np.sin(2*theta)**2 - A2) < 1e-10
+    # logical_list = numqi.qec.get_transversal_group(code, num_round=40, tag_print=True)
+    # info = numqi.qec.get_transversal_group_info([x[0] for x in logical_list])
+
+    I,X,Y,Z = numqi.gate.I, numqi.gate.X, numqi.gate.Y, numqi.gate.Z
+    tmp0 = [X,I,Y,Y,I,I]
+    np1 = code.conj() @ hf_kron(*tmp0) @ code.T
+    assert np.abs(np1 - numqi.gate.X).max() < 1e-10
+    tmp0 = [-Y,Z,Y,I,I,I]
+    np1 = code.conj() @ hf_kron(*tmp0) @ code.T
+    assert np.abs(np1 - numqi.gate.Z).max() < 1e-10
+
+
+def test_code523_u4_weight_enumerator():
+    code523,_ = numqi.qec.get_code_subspace('523')
+    z0 = []
+    for _ in range(10):
+        su4 = numqi.random.rand_haar_unitary(4)
+        code = (np.stack([code523,code523*0], axis=2).reshape(-1,4) @ su4.T).reshape(2,-1)
+        z0.append(numqi.qec.get_weight_enumerator(code, tagB=False))
+    z0 = np.stack(z0)
+    assert np.abs(z0[:,0]-1).max() < 1e-10
+    assert np.abs(z0[:,1]+z0[:,2]-1).max() < 1e-10
+    assert np.abs(z0[:,3]).max() < 1e-10
+    assert np.abs(4*z0[:,1] - z0[:,4] + 11).max() < 1e-10
+    assert np.abs(z0[:,1] + z0[:,5] - 16).max() < 1e-10
+    assert np.abs(-3*z0[:,1] - z0[:,6] + 3).max() < 1e-10

--- a/tests/test_qec/test_q623.py
+++ b/tests/test_qec/test_q623.py
@@ -1,0 +1,144 @@
+import functools
+import numpy as np
+import numqi
+
+np_rng = np.random.default_rng()
+hf_kron = lambda *x: functools.reduce(np.kron, x)
+
+
+def test_get_transversal_gate623():
+    # 623-SO5
+    a,b = np_rng.normal(size=2)
+    vece = np.array([a,b,0,0,0])/np.sqrt(a*a+b*b)
+    # vece = np.array([1,0,0,0,0])
+    code = numqi.qec.q623.get_SO5_code(vece)
+    logical_list = numqi.qec.get_transversal_group(code, num_round=20, tag_print=False)
+    assert len(logical_list)==8 #BD_2
+    # info = numqi.qec.get_transversal_group_info([x[0] for x in logical_list])
+
+    a,b,c = np_rng.normal(size=3)
+    vece = np.array([a,b,c,0,0])/np.sqrt(a*a+b*b+c*c)
+    code = numqi.qec.q623.get_SO5_code(vece)
+    logical_list = numqi.qec.get_transversal_group(code, num_round=20, tag_print=False)
+    assert len(logical_list)==4, f'{a},{b},{c}' #C4
+
+    a,b,c,d = np_rng.normal(size=4)
+    vece = np.array([a,b,c,d,0])/np.sqrt(a*a+b*b+c*c+d*d)
+    code = numqi.qec.q623.get_SO5_code(vece)
+    logical_list = numqi.qec.get_transversal_group(code, num_round=20, tag_print=True)
+    assert len(logical_list)==2, f'a,b,c,d={[a,b,c,d]}' #C2
+
+    # tmp0 = np_rng.normal(size=5)
+    # vece = tmp0/np.linalg.norm(tmp0)
+    # code = numqi.qec.q623.get_SO5_code(vece)
+    # logical_list = numqi.qec.get_transversal_group(code, num_round=20, tag_print=True)
+    # assert len(logical_list)==2 #C2
+
+    # ((6,2,3)) stab
+    code,info = numqi.qec.get_code_subspace('623stab')
+    logical_list = numqi.qec.get_transversal_group(code, num_round=40, tag_print=True)
+    assert len(logical_list)==8 #BD4
+
+    # # ((6,2,3)) from ((5,2,3))
+    # code523,_ = numqi.qec.get_code_subspace('523')
+    # tmp0 = numqi.random.rand_haar_unitary(4)
+    # tmp1 = np.stack([code523,code523*0], axis=2).reshape(2,-1)
+    # code623 = np.einsum(tmp1.reshape(-1,4), [0,1], tmp0, [3,1], [0,3], optimize=True).reshape(2,-1)
+    # logical_list = numqi.qec.get_transversal_group(code623, num_round=20, tag_print=True)
+    # assert len(logical_list)==8 #BD8
+
+
+def test_623SO5_transversal_group_BD4():
+    tmp0 = np_rng.normal(size=(2))
+    r,s = tmp0/np.linalg.norm(tmp0)
+    matO = 0.5*np.array([[-s,s,-s,s,2*r], [r,-r,r,-r,2*s], [1,1,1,1,0], [1,-1,-1,1,0], [1,1,-1,-1,0]])
+    veca,vecb,vecc,vecd,vece = matO.T/2
+    basis = numqi.qec.q623.get_SO5_code_basis()
+    coeff0 = np.concatenate([veca+1j*vecb, vecc+1j*vecd], axis=0)
+    coeff1 = np.concatenate([coeff0[5:].conj(), -coeff0[:5].conj()], axis=0)
+    code = np.stack([coeff0, coeff1], axis=0) @ basis
+
+    basisS = basis.reshape(10,2,32)[:5,0]
+    tmp0 = np.array([[-s,0], [r,0], [1j,0], [0,1], [0,1j]]) @ numqi.gate.H
+    q0 = (tmp0.T @ basisS).reshape(-1) / (2*np.exp(1j*np.pi/4))
+    assert np.abs(q0 - code[0]).max() < 1e-10
+    tmp0 = np.array([[0,-1j*s], [0,1j*r], [0,1], [-1j,0], [-1,0]]) @ numqi.gate.H
+    q1 = (tmp0.T @ basisS).reshape(-1) / (2*np.exp(1j*np.pi/4))
+    assert np.abs(q1 - code[1]).max() < 1e-10
+
+    X,Y,Z,I = numqi.gate.X, numqi.gate.Y, numqi.gate.Z, numqi.gate.I
+    s3 = np.sqrt(3)
+    tmp0 = np.stack([2*Y, s3*X+Y, X-s3*Y, s3*X+Y, X-s3*Y, X-s3*Y], axis=0) * 0.5j
+    logicalX = code.conj() @ hf_kron(*tmp0) @ code.T
+    assert np.abs(logicalX - X).max() < 1e-10
+    tmp0 = np.stack([1j*X, 1j*Z, 1j*Z, I, I, I], axis=0)
+    logicalZ = code.conj() @ hf_kron(*tmp0) @ code.T
+    assert np.abs(1j*logicalZ - Z).max() < 1e-10
+
+
+def test_623SO5_transversal_group_C4():
+    tmp0 = np_rng.normal(size=3)
+    r,s,t = tmp0/np.linalg.norm(tmp0)
+    alpha = np.arccos(t/np.sqrt(t*t+1)) + np.arctan(s/r)
+    beta = -np.arccos(t/np.sqrt(t*t+1)) + np.arctan(s/r)
+    a1 = np.sqrt(t*t+1)*np.cos(alpha)
+    a2 = np.sqrt(t*t+1)*np.sin(alpha)
+    b1 = np.sqrt(t*t+1)*np.cos(beta)
+    b2 = np.sqrt(t*t+1)*np.sin(beta)
+    a3 = -(a1*r + a2*s)/t
+    matO = 0.5*np.array([[a1,b1,a1,b1,2*r], [a2,b2,a2,b2,2*s], [a3,a3,a3,a3,2*t], [1,-1,-1,1,0], [1,1,-1,-1,0]]).T
+    assert np.abs(matO@matO.T - np.eye(5)).max() < 1e-10
+
+    veca,vecb,vecc,vecd,vece = matO/2
+    basis = numqi.qec.q623.get_SO5_code_basis()
+    coeff0 = np.concatenate([veca+1j*vecb, vecc+1j*vecd], axis=0)
+    coeff1 = np.concatenate([coeff0[5:].conj(), -coeff0[:5].conj()], axis=0)
+    code = np.stack([coeff0, coeff1], axis=0) @ basis
+
+    X,Y,Z,I = numqi.gate.X, numqi.gate.Y, numqi.gate.Z, numqi.gate.I
+    tmp0 = np.stack([1j*X, 1j*Z, 1j*Z, I, I, I], axis=0)
+    logicalZ = code.conj() @ hf_kron(*tmp0) @ code.T
+    assert np.abs(1j*logicalZ - Z).max() < 1e-10
+
+
+def test_623stab_code():
+    op_list = numqi.qec.make_pauli_error_list_sparse(num_qubit=6, distance=3, kind='scipy-csr01')[1]
+    code,_ = numqi.qec.get_code_subspace('623stab')
+    z0 = code.conj() @ (op_list @ code.T).reshape(-1, 2**6, 2)
+    assert np.abs(z0[:,0,1]).max() < 1e-10
+    assert np.abs(z0[:,0,0] - z0[:,1,1]).max() < 1e-10
+    tmp1 = np.zeros(153, dtype=np.float64)
+    tmp1[143] = 1
+    assert np.abs(z0[:,0,0]-tmp1).max() < 1e-12
+    weightA, weightB = numqi.qec.get_weight_enumerator(code, use_circuit=True, tagB=True)
+    weightA_ = np.array([1,0,1,0,11,16,3])
+    weightB_ = np.array([1,0,1,24,35,40,27])
+    assert np.abs(weightA-weightA_).max() < 1e-12
+    assert np.abs(weightB-weightB_).max() < 1e-12
+
+
+def test_get_SO5_code_quantum_weight_enumerator():
+    for _ in range(5):
+        vece = numqi.random.rand_haar_state(5, tag_complex=False)
+        code,info = numqi.qec.q623.get_SO5_code(vece, return_info=True)
+        error_str,error_scipy = numqi.qec.make_pauli_error_list_sparse(6, distance=3, kind='scipy-csr01')
+        z0 = code.conj() @ (error_scipy @ code.T).reshape(-1,64,2)
+        assert np.abs(z0[:,0,1]).max() < 1e-10
+        assert np.abs(z0[:,1,0]).max() < 1e-10
+        assert np.abs(z0[:,0,0]-z0[:,1,1]).max() < 1e-10
+        assert np.abs(z0[:,0,0].real - info['lambda_ai']).max() < 1e-10
+        weightA,weightB = numqi.qec.get_weight_enumerator(code)
+        assert np.abs(weightA-info['qweA']).max() < 1e-10
+        assert np.abs(weightB-info['qweB']).max() < 1e-10
+
+def test_get_623C10():
+    code,info = numqi.qec.q623.get_C10(return_info=True)
+    error_str,error_scipy = numqi.qec.make_pauli_error_list_sparse(6, distance=3, kind='scipy-csr01')
+    z0 = code.conj() @ (error_scipy @ code.T).reshape(-1,64,2)
+    assert np.abs(z0[:,0,1]).max() < 1e-10
+    assert np.abs(z0[:,1,0]).max() < 1e-10
+    assert np.abs(z0[:,0,0]-z0[:,1,1]).max() < 1e-10
+    qweA,qweB = numqi.qec.get_weight_enumerator(code)
+    assert np.abs(qweA - info['qweA']).max() < 1e-10
+    assert np.abs(qweB - info['qweB']).max() < 1e-10
+    assert np.abs(numqi.gate.rz(-2*np.pi/5) - code.conj() @ hf_kron(*info['su2']) @ code.T).max() < 1e-10

--- a/tests/test_qec/test_q723.py
+++ b/tests/test_qec/test_q723.py
@@ -1,0 +1,469 @@
+import itertools
+import functools
+import numpy as np
+import numqi
+
+np_rng = np.random.default_rng()
+hf_kron = lambda *x: functools.reduce(np.kron, x)
+
+def test_723bare_code():
+    code,info = numqi.qec.get_code_subspace('723bare')
+    op_list = numqi.qec.make_pauli_error_list_sparse(num_qubit=7, distance=3, kind='numpy')[1]
+    z0 = code.conj() @ (op_list @ code.T)
+    assert np.abs(z0[:,0,1]).max() < 1e-12
+    assert np.abs(z0[:,0,0] - z0[:,1,1]).max() < 1e-12
+    assert abs(np.linalg.norm(z0[:,0,0].real)**2-5) < 1e-10
+    # "XXIIIII XIIIXII IXIIXII IIXIIXI IIIXIIX" is 1
+
+
+def test_steane_code():
+    code,info = numqi.qec.get_code_subspace('steane')
+    op_list = numqi.qec.make_pauli_error_list_sparse(num_qubit=7, distance=3, kind='scipy-csr01')[1]
+    z0 = code.conj() @ (op_list @ code.T).reshape(-1, 2**7, 2)
+    assert np.abs(z0).max() < 1e-10
+
+
+def test_get_723_cyclic_code():
+    error_str_list,op_list = numqi.qec.make_pauli_error_list_sparse(num_qubit=7, distance=3, kind='scipy-csr01')
+    lambda2 = np_rng.uniform(0, 7)
+    for sign in ['++', '+-', '-+', '--']:
+        coeff,lambda_ai_dict,basis = numqi.qec.q723.get_cyclic_code(lambda2, sign=sign)
+        q0 = coeff @ basis
+        z0 = q0.conj() @ (op_list @ q0.T).reshape(-1, 2**7, 2)
+        assert np.abs(z0.imag).max() < 1e-12
+        assert np.abs(z0[:,0,1]).max() < 1e-12
+        assert np.abs(z0[:,1,0]).max() < 1e-12
+        assert np.abs(z0[:,0,0] - z0[:,1,1]).max() < 1e-12
+        z0 = z0[:,0,0].real
+        z1 = np.array([lambda_ai_dict.get(x,0) for x in error_str_list])
+        assert np.abs(z0-z1).max() < 1e-12
+
+
+def test_723_cyclic_code_weight_enumerator():
+    wt_to_pauli_dict = {x:numqi.qec.get_pauli_with_weight_sparse(7,x)[1] for x in range(1,8)} #slow 11 seconds
+    for _ in range(5):
+        lambda2 = np_rng.uniform(0, 7)
+        code,info = numqi.qec.get_code_subspace('723cyclic', lambda2=lambda2)
+        weightA,weightB = numqi.qec.get_weight_enumerator(code, wt_to_pauli_dict=wt_to_pauli_dict)
+        assert np.abs(weightA-info['qweA']).max() < 1e-10
+        assert np.abs(weightB-info['qweB']).max() < 1e-10
+
+    code523,info = numqi.qec.get_code_subspace('523')
+    code723 = np.concatenate([code523.reshape(2,32,1), np.zeros((2,32,3))], axis=2).reshape(2,128)
+    weightA,weightB = numqi.qec.get_weight_enumerator(code723, wt_to_pauli_dict=wt_to_pauli_dict)
+    weightA_ = np.array([1,2,1,0,15,30,15,0])
+    weightB_ = np.array([1,2,1,30,75,78,51,18])
+    assert np.abs(weightA-weightA_).max() < 1e-10
+    assert np.abs(weightB-weightB_).max() < 1e-10
+
+
+def test_get_2I_lambda0():
+    theta,phi = np_rng.uniform(0, 2*np.pi, size=2)
+    sign = '+' if np_rng.random() > 0.5 else '-'
+    code,info = numqi.qec.q723.get_2I_lambda0(theta, phi, sign, return_info=True)
+    error_str,error_scipy = numqi.qec.make_pauli_error_list_sparse(7, distance=3, kind='scipy-csr01')
+    z0 = code.conj() @ ((error_scipy @ code.T).reshape(-1, 128, 2))
+    assert np.abs(z0).max() < 1e-10 #non-degenerate
+    assert np.abs(code.conj() @ numqi.qec.hf_pauli('X'*7) @ code.T - numqi.gate.X).max() < 1e-10
+    assert np.abs(code.conj() @ hf_kron(*info['su2']) @ code.T - numqi.gate.rz(2*np.pi/5)).max() < 1e-10
+    assert np.abs(code.conj() @ hf_kron(*info['su2R']) @ code.T - info['transR']).max() < 1e-10
+    qweA,qweB = numqi.qec.get_weight_enumerator(code)
+    assert np.abs(qweA - info['qweA']).max() < 1e-10
+    assert np.abs(qweB - info['qweB']).max() < 1e-10
+
+    # 2I but not KL
+    x0 = np.array([0,1,1,0])/np.sqrt(2)
+    subspace = np.stack([x0@info['basis0'], x0@info['basis1']], axis=0)
+    assert np.abs(subspace.conj() @ hf_kron(*info['su2R']) @ subspace.T - info['transR']).max() < 1e-10
+    z0 = subspace.conj() @ ((error_scipy @ subspace.T).reshape(-1, 128, 2))
+    assert np.abs(z0[:,0,1]).max() > 0.1 #not satisfy KL condition
+
+
+def test_get_2I_lambda075():
+    error_str,error_scipy = numqi.qec.make_pauli_error_list_sparse(7, distance=3, kind='scipy-csr01')
+    for sign in itertools.product([-1,1], repeat=3):
+        t = np_rng.uniform(-np.sqrt(5)/4, np.sqrt(5)/4)
+        code,info = numqi.qec.q723.get_2I_lambda075(t, sign, return_info=True)
+        z0 = code.conj() @ (error_scipy @ code.T).reshape(-1,2**7,2)
+        assert np.abs(z0[:,0,1]).max() < 1e-10
+        assert np.abs(z0[:,1,0]).max() < 1e-10
+        assert np.abs(z0[:,0,0]-z0[:,1,1]).max() < 1e-10
+        assert np.abs(z0[:,0,0].imag).max() < 1e-10
+        assert np.abs(z0[:,0,0]-info['lambda_ai']).max() < 1e-10
+        assert np.abs(code.conj() @ numqi.qec.hf_pauli('X'*7) @ code.T - numqi.gate.X).max() < 1e-10
+        assert np.abs(code.conj() @ hf_kron(*info['su2']) @ code.T - numqi.gate.rz(-2*np.pi/5)).max() < 1e-10
+        assert np.abs(code.conj() @ hf_kron(*info['su2R']) @ code.T - info['transR']).max() < 1e-10
+        qweA,qweB = numqi.qec.get_weight_enumerator(code)
+        assert np.abs(qweA - info['qweA']).max() < 1e-10
+        assert np.abs(qweB - info['qweB']).max() < 1e-10
+
+
+def test_get_BD12_veca1112222():
+    sign = np_rng.integers(2, size=10)*2-1
+    sign[6] = -sign[1]*sign[3]*sign[5]
+    sign[8] = -sign[2]*sign[4]*sign[7]
+    code,info = numqi.qec.q723.get_BD12_veca1112222(sign=sign, return_info=True)
+
+    error_str,error_scipy = numqi.qec.make_pauli_error_list_sparse(7, distance=3, kind='scipy-csr01')
+    z0 = code.conj() @ ((error_scipy @ code.T).reshape(-1, 128, 2))
+    assert np.abs(z0[:,0,1]).max() < 1e-10
+    assert np.abs(z0[:,1,0]).max() < 1e-10
+    assert np.abs(z0[:,0,0]-z0[:,1,1]).max() < 1e-10
+    assert np.abs(z0[:,0,0].imag).max() < 1e-10
+    qweA, qweB = numqi.qec.get_weight_enumerator(code, tagB=True)
+    assert np.abs(qweA - info['qweA']).max() < 1e-10
+    assert np.abs(qweB - info['qweB']).max() < 1e-10
+    logicalU = code.conj() @ hf_kron(*info['su2']) @ code.T
+    assert np.abs(numqi.gate.rz(-2*np.pi/6) - logicalU).max() < 1e-10
+
+
+def test_get_BD12_veca0122233():
+    a = np_rng.uniform(0, np.sqrt(2/3))
+    sign = np_rng.integers(2, size=4)*2 - 1
+    sign[3] = sign[0]*sign[1]*sign[2]
+
+    code,info = numqi.qec.q723.get_BD12_veca0122233(a, sign=sign, return_info=True)
+    error_str,error_scipy = numqi.qec.make_pauli_error_list_sparse(7, distance=3, kind='scipy-csr01')
+    z0 = code.conj() @ (error_scipy @ code.T).reshape(-1,128,2)
+    assert np.abs(z0[:,0,1]).max() < 1e-10
+    assert np.abs(z0[:,1,0]).max() < 1e-10
+    assert np.abs(z0[:,0,0]-z0[:,1,1]).max() < 1e-10
+    assert np.abs(z0[:,0,0].imag).max() < 1e-10
+    assert np.abs(z0[:,0,0] - info['lambda_ai']).max() < 1e-10
+    qweA,qweB = numqi.qec.get_weight_enumerator(code, tagB=True)
+    assert np.abs(qweA - info['qweA']).max() < 1e-10
+    assert np.abs(qweB - info['qweB']).max() < 1e-10
+    logicalU = code.conj() @ hf_kron(*info['su2']) @ code.T
+    assert np.abs(numqi.gate.rz(2*np.pi/6) - logicalU).max() < 1e-10
+
+
+def test_get_BD14():
+    a = np_rng.uniform(0, 1/np.sqrt(14))
+    sign = np_rng.integers(2, size=5) * 2 -1
+    code,info = numqi.qec.q723.get_BD14(a, sign, return_info=True)
+    error_str,error_scipy = numqi.qec.make_pauli_error_list_sparse(7, distance=3, kind='scipy-csr01')
+    z0 = code.conj() @ ((error_scipy @ code.T).reshape(-1, 128, 2))
+    assert np.abs(z0[:,0,1]).max() < 1e-10
+    assert np.abs(z0[:,1,0]).max() < 1e-10
+    assert np.abs(z0[:,0,0]-z0[:,1,1]).max() < 1e-10
+    assert np.abs(z0[:,0,0].imag).max() < 1e-10
+    assert np.abs(z0[:,0,0] - info['lambda_ai']).max() < 1e-10
+    qweA, qweB = numqi.qec.get_weight_enumerator(code, tagB=True)
+    assert np.abs(qweA - info['qweA']).max() < 1e-10
+    assert np.abs(qweB - info['qweB']).max() < 1e-10
+    logicalU = code.conj() @ hf_kron(*info['su2']) @ code.T
+    assert np.abs(numqi.gate.rz(-2*np.pi/7) - logicalU).max() < 1e-10
+
+
+def test_get_BD16_5theta():
+    theta = np_rng.uniform(0, 2*np.pi, 5)
+    code,info = numqi.qec.q723.get_BD16_5theta(theta, return_info=True)
+    logicalU = code.conj() @ hf_kron(*info['su2Z']) @ code.T
+    assert np.abs(logicalU-numqi.gate.rz(-np.pi/4)).max() < 1e-10
+    logicalU = code.conj() @ hf_kron(*info['su2X']) @ code.T
+    assert np.abs(logicalU-numqi.gate.X).max() < 1e-10
+
+    error_str,error_scipy = numqi.qec.make_pauli_error_list_sparse(7, distance=3, kind='scipy-csr01')
+    z0 = code.conj() @ (error_scipy @ code.T).reshape(-1,2**7,2)
+    assert np.abs(z0[:,0,1]).max() < 1e-10
+    assert np.abs(z0[:,1,0]).max() < 1e-10
+    assert np.abs(z0[:,0,0] - z0[:,1,1]).max() < 1e-10
+    qweA,qweB = numqi.qec.get_weight_enumerator(code, tagB=True)
+    assert np.abs(qweA - info['qweA']).max() < 1e-10
+    assert np.abs(qweB - info['qweB']).max() < 1e-10
+
+    ## theta=0, stabilizer
+    code,info = numqi.qec.q723.get_BD16_5theta(np.zeros(5), return_info=True)
+    swap = numqi.gate.Swap
+    I = numqi.gate.I
+    assert np.abs(code.conj() @ numqi.qec.hf_pauli('IIIIIXX') @ code.T - I).max() < 1e-10
+    a = np_rng.uniform(0, 2*np.pi) #X6(a)X7(-a)
+    tmp0 = hf_kron(np.eye(2**5), numqi.gate.rx(a), numqi.gate.rx(-a))
+    assert np.abs(code.conj() @ tmp0 @ code.T - I).max() < 1e-10
+    op = np.kron(swap, np.eye(32)) #S(1,2)
+    assert np.abs(code.conj() @ op @ code.T - I).max() < 1e-10
+    op = hf_kron(np.eye(2), swap, np.eye(16)) #S(2,3)
+    assert np.abs(code.conj() @ op @ code.T - I).max() < 1e-10
+    op = hf_kron(np.eye(8), swap, np.eye(4)) #S(4,5)
+    assert np.abs(code.conj() @ op @ code.T - I).max() < 1e-10
+    op = np.kron(np.eye(32), numqi.gate.Swap) #S(6,7)
+    assert np.abs(code.conj() @ op @ code.T - I).max() < 1e-10
+
+
+def test_get_BD16_veca1222233():
+    theta = np_rng.uniform(0, 2*np.pi, size=2)
+    sign = np_rng.integers(2, size=7)*2 - 1
+    code,info = numqi.qec.q723.get_BD16_veca1222233(theta[0], theta[1], sign=sign, return_info=True)
+
+    error_str,error_scipy = numqi.qec.make_pauli_error_list_sparse(7, distance=3, kind='scipy-csr01')
+    z0 = code.conj() @ (error_scipy @ code.T).reshape(-1,2**7,2)
+    assert np.abs(z0[:,0,1]).max() < 1e-10
+    assert np.abs(z0[:,1,0]).max() < 1e-10
+    assert np.abs(z0[:,0,0] - z0[:,1,1]).max() < 1e-10
+    qweA,qweB = numqi.qec.get_weight_enumerator(code, tagB=True)
+    assert np.abs(qweA - info['qweA']).max() < 1e-10
+    assert np.abs(qweB - info['qweB']).max() < 1e-10
+    logicalU = code.conj() @ hf_kron(*info['su2']) @ code.T
+    assert np.abs(numqi.gate.rz(-2*np.pi/8) - logicalU).max() < 1e-10
+
+
+def test_get_BD16_degenerate():
+    theta = np_rng.uniform(0, 2*np.pi)
+    sign = np_rng.integers(2, size=8)*2-1
+    sign[5] = -sign[0]*sign[1]*sign[4]
+    code, info = numqi.qec.q723.get_BD16_degenerate(theta=theta, sign=sign, return_info=True)
+
+    error_scipy = numqi.qec.make_pauli_error_list_sparse(7, distance=3, kind='scipy-csr01')[1]
+    z0 = code.conj() @ (error_scipy @ code.T).reshape(-1,128,2)
+    assert np.abs(z0[:,0,1]).max() < 1e-10
+    assert np.abs(z0[:,1,0]).max() < 1e-10
+    assert np.abs(z0[:,0,0]-z0[:,1,1]).max() < 1e-10
+    qweA,qweB = numqi.qec.get_weight_enumerator(code, tagB=True)
+    assert np.abs(qweA - info['qweA']).max() < 1e-10
+    assert np.abs(qweB - info['qweB']).max() < 1e-10
+    lambda_a = z0[:,0,0].real
+    assert np.abs(lambda_a - info['lambda_a']).max() < 1e-10
+    assert abs(np.linalg.norm(lambda_a)**2-2.25) < 1e-10
+    lambda_ab = (np.insert(lambda_a, 0, 1)[numqi.qec.get_knill_laflamme_matrix_indexing_over_vector(num_qubit=7, distance=3)]).reshape(22,22)
+    EVL = np.linalg.eigvalsh(lambda_ab)
+    assert np.abs(EVL - info['lambda_ab_EVL']).max() < 1e-10
+    assert abs(EVL[0]) < 1e-12
+
+    su2 = info['su2']
+    logicalU = code.conj() @ hf_kron(*su2) @ code.T
+    assert np.abs(numqi.gate.rz(-2*np.pi/8) - logicalU).max() < 1e-10
+
+
+def test_get_BD18():
+    theta = np_rng.uniform(0, 2*np.pi)
+    root = np_rng.choice([0,1])
+    sign = np_rng.integers(2, size=8) * 2 -1
+    code,info = numqi.qec.q723.get_BD18(theta, root, sign, return_info=True)
+    error_str,error_scipy = numqi.qec.make_pauli_error_list_sparse(7, distance=3, kind='scipy-csr01')
+    z0 = code.conj() @ ((error_scipy @ code.T).reshape(-1, 128, 2))
+    assert np.abs(z0[:,0,1]).max() < 1e-10
+    assert np.abs(z0[:,1,0]).max() < 1e-10
+    assert np.abs(z0[:,0,0]-z0[:,1,1]).max() < 1e-10
+    assert np.abs(z0[:,0,0].imag).max() < 1e-10
+    assert np.abs(z0[:,0,0].real-info['lambda_ai']).max() < 1e-10
+    qweA,qweB = numqi.qec.get_weight_enumerator(code, tagB=True)
+    assert np.abs(qweA-info['qweA']).max() < 1e-10
+    assert np.abs(qweB-info['qweB']).max() < 1e-10
+    logicalU = code.conj() @ hf_kron(*info['su2']) @ code.T
+    assert np.abs(numqi.gate.rz(-2*np.pi/9) - logicalU).max() < 1e-10
+
+
+def test_get_BD18_LP():
+    code,info = numqi.qec.q723.get_BD18_LP(coeff2=None, sign=None, return_info=True)
+    error_str,error_scipy = numqi.qec.make_pauli_error_list_sparse(7, distance=3, kind='scipy-csr01')
+    z0 = code.conj() @ (error_scipy @ code.T).reshape(-1,2**7,2)
+    assert np.abs(z0[:,0,1]).max() < 1e-8 #cvxpy precision is not good
+    assert np.abs(z0[:,1,0]).max() < 1e-8
+    assert np.abs(z0[:,0,0] - z0[:,1,1]).max() < 1e-8
+    logicalU = code.conj() @ hf_kron(*info['su2']) @ code.T
+    assert np.abs(numqi.gate.rz(-2*np.pi/9) - logicalU).max() < 1e-10
+    # qweA, qweB = numqi.qec.get_weight_enumerator(code, tagB=True)
+
+
+def test_get_BD20():
+    a = np_rng.uniform(0, np.sqrt(1/5))
+    sign = np_rng.integers(2, size=5)*2 - 1
+    code, info = numqi.qec.q723.get_BD20(a, sign, return_info=True)
+
+    error_str,error_scipy = numqi.qec.make_pauli_error_list_sparse(7, distance=3, kind='scipy-csr01')
+    z0 = code.conj() @ ((error_scipy @ code.T).reshape(-1, 128, 2))
+    assert np.abs(z0[:,0,1]).max() < 1e-10
+    assert np.abs(z0[:,1,0]).max() < 1e-10
+    assert np.abs(z0[:,0,0]-z0[:,1,1]).max() < 1e-10
+    assert np.abs(z0[:,0,0].imag).max() < 1e-10
+    assert np.abs(z0[:,0,0]-info['lambda_ai']).max() < 1e-10
+    qweA, qweB = numqi.qec.get_weight_enumerator(code, tagB=True)
+    assert np.abs(qweA - info['qweA']).max() < 1e-10
+    assert np.abs(qweB - info['qweB']).max() < 1e-10
+    logicalU = code.conj() @ hf_kron(*info['su2']) @ code.T
+    assert np.abs(numqi.gate.rz(-2*np.pi/10) - logicalU).max() < 1e-10
+
+
+def test_get_BD22():
+    sign = np_rng.integers(2, size=5)*2 - 1
+    a = np_rng.uniform(0, np.sqrt(3/22))
+    code,info = numqi.qec.q723.get_BD22(a, sign=sign, return_info=True)
+
+    error_str,error_scipy = numqi.qec.make_pauli_error_list_sparse(7, distance=3, kind='scipy-csr01')
+    z0 = code.conj() @ ((error_scipy @ code.T).reshape(-1, 128, 2))
+    assert np.abs(z0[:,0,1]).max() < 1e-10
+    assert np.abs(z0[:,1,0]).max() < 1e-10
+    assert np.abs(z0[:,0,0]-z0[:,1,1]).max() < 1e-10
+    assert np.abs(z0[:,0,0].imag).max() < 1e-10
+    assert np.abs(z0[:,0,0]-info['lambda_ai']).max() < 1e-10
+    qweA, qweB = numqi.qec.get_weight_enumerator(code, tagB=True)
+    assert np.abs(qweA - info['qweA']).max() < 1e-10
+    assert np.abs(qweB - info['qweB']).max() < 1e-10
+    logicalU = code.conj() @ hf_kron(*info['su2']) @ code.T
+    assert np.abs(numqi.gate.rz(-2*np.pi/11) - logicalU).max() < 1e-10
+
+
+def test_get_BD24():
+    error_str,error_scipy = numqi.qec.make_pauli_error_list_sparse(7, distance=3, kind='scipy-csr01')
+    for sign in '+-':
+        code,info = numqi.qec.q723.get_BD24(sign=sign, return_info=True)
+        z0 = code.conj() @ (error_scipy @ code.T).reshape(-1,128,2)
+        assert np.abs(z0[:,0,1]).max() < 1e-10
+        assert np.abs(z0[:,1,0]).max() < 1e-10
+        assert np.abs(z0[:,0,0]-z0[:,1,1]).max() < 1e-10
+        assert np.abs(z0[:,0,0].imag).max() < 1e-10
+        z0 = z0[:,0,0].real
+        qweA,qweB = numqi.qec.get_weight_enumerator(code, tagB=True)
+        assert np.abs(qweA-info['qweA']).max() < 1e-10
+        assert np.abs(qweB-info['qweB']).max() < 1e-10
+
+        np0 = code.conj() @ hf_kron(*[numqi.gate.X]*7) @ code.T
+        assert np.abs(numqi.gate.X - np0).max() < 1e-12
+        np0 = code.conj() @ hf_kron(*info['su2']) @ code.T
+        assert np.abs(numqi.gate.rz(np.pi/6) - np0).max() < 1e-12
+
+
+def test_get_BD26():
+    sign = np_rng.integers(2, size=5)*2 - 1
+    a = np_rng.uniform(0, np.sqrt(2/13))
+    code, info = numqi.qec.q723.get_BD26(a, sign=sign, return_info=True)
+    error_str,error_scipy = numqi.qec.make_pauli_error_list_sparse(7, distance=3, kind='scipy-csr01')
+    z0 = code.conj() @ (error_scipy @ code.T).reshape(-1,128,2)
+    assert np.abs(z0[:,0,1]).max() < 1e-10
+    assert np.abs(z0[:,1,0]).max() < 1e-10
+    assert np.abs(z0[:,0,0]-z0[:,1,1]).max() < 1e-10
+    assert np.abs(z0[:,0,0] - info['lambda_ai']).max() < 1e-10
+    qweA, qweB = numqi.qec.get_weight_enumerator(code, tagB=True)
+    assert np.abs(qweA - info['qweA']).max() < 1e-10
+    assert np.abs(qweB - info['qweB']).max() < 1e-10
+    logicalU = code.conj() @ hf_kron(*info['su2']) @ code.T
+    assert np.abs(numqi.gate.rz(-2*np.pi/13) - logicalU).max() < 1e-10
+
+
+def test_get_BD28():
+    a = np_rng.uniform(0, np.sqrt(1/14))
+    sign = np_rng.integers(2, size=5)*2-1
+    code,info = numqi.qec.q723.get_BD28(a, sign, return_info=True)
+
+    error_str,error_scipy = numqi.qec.make_pauli_error_list_sparse(7, distance=3, kind='scipy-csr01')
+    z0 = code.conj() @ (error_scipy @ code.T).reshape(-1,128,2)
+    assert np.abs(z0[:,0,1]).max() < 1e-10
+    assert np.abs(z0[:,1,0]).max() < 1e-10
+    assert np.abs(z0[:,0,0]-z0[:,1,1]).max() < 1e-10
+    assert np.abs(z0[:,0,0]-info['lambda_ai']).max() < 1e-10
+    qweA,qweB = numqi.qec.get_weight_enumerator(code, tagB=True)
+    assert np.abs(qweA - info['qweA']).max() < 1e-10
+    assert np.abs(qweB - info['qweB']).max() < 1e-10
+
+    logicalU = code.conj() @ hf_kron(*info['su2']) @ code.T
+    assert np.abs(numqi.gate.rz(-2*np.pi/14) - logicalU).max() < 1e-10
+
+
+def test_get_BD30():
+    a = np_rng.uniform(np.sqrt(1/15), np.sqrt(7/30))
+    sign = np_rng.integers(2, size=5)*2 - 1
+    code, info = numqi.qec.q723.get_BD30(a, sign=sign, return_info=True)
+    error_scipy = numqi.qec.make_pauli_error_list_sparse(7, distance=3, kind='scipy-csr01')[1]
+    z0 = code.conj() @ (error_scipy @ code.T).reshape(-1,128,2)
+    assert np.abs(z0[:,0,1]).max() < 1e-10
+    assert np.abs(z0[:,1,0]).max() < 1e-10
+    assert np.abs(z0[:,0,0]-z0[:,1,1]).max() < 1e-10
+    assert np.abs(z0[:,0,0]-info['lambda_ai']).max() < 1e-10
+    # assert abs(np.linalg.norm(z0[:,0,0])**2 - info['A2']) < 1e-10
+    qweA,qweB = numqi.qec.get_weight_enumerator(code, tagB=True)
+    assert np.abs(qweA - info['qweA']).max() < 1e-10
+    assert np.abs(qweB - info['qweB']).max() < 1e-10
+    su2 = info['su2']
+    logicalU = code.conj() @ hf_kron(*su2) @ code.T
+    assert np.abs(numqi.gate.rz(-2*np.pi/15) - logicalU).max() < 1e-10
+
+
+def test_get_723_BD32_code():
+    error_str,error_scipy = numqi.qec.make_pauli_error_list_sparse(7, distance=3, kind='scipy-csr01')
+    a = np_rng.uniform(0, 1/np.sqrt(8))
+    sign = np_rng.integers(2, size=9)*2 - 1
+    code, info = numqi.qec.q723.get_BD32(a, sign, return_info=True)
+
+    z0 = code.conj() @ ((error_scipy @ code.T).reshape(-1, 128, 2))
+    assert np.abs(z0[:,0,1]).max() < 1e-10
+    assert np.abs(z0[:,1,0]).max() < 1e-10
+    assert np.abs(z0[:,0,0]-z0[:,1,1]).max() < 1e-10
+    assert np.abs(z0[:,0,0].imag).max() < 1e-10
+    assert np.abs(z0[:,0,0]-info['lambda_ai']).max() < 1e-10
+    qweA,qweB = numqi.qec.get_weight_enumerator(code, tagB=True)
+    assert np.abs(qweA - info['qweA']).max() < 1e-10
+    assert np.abs(qweB - info['qweB']).max() < 1e-10
+
+    np0 = code.conj() @ numqi.qec.hf_pauli('XXXXXXX') @ code.T
+    assert np.abs(np0-numqi.gate.X).max() < 1e-10
+    np0 = code.conj() @ hf_kron(*info['su2']) @ code.T
+    assert np.abs(np0 - numqi.gate.rz(-2*np.pi/16)).max() < 1e-10
+
+
+def test_get_BD34():
+    sign = np_rng.integers(2, size=8)*2-1
+    theta = np_rng.uniform(0, 2*np.pi)
+    code, info = numqi.qec.q723.get_BD34(sign=sign, theta=theta, return_info=True)
+
+    error_scipy = numqi.qec.make_pauli_error_list_sparse(7, distance=3, kind='scipy-csr01')[1]
+    z0 = code.conj() @ (error_scipy @ code.T).reshape(-1,128,2)
+    assert np.abs(z0[:,0,1]).max() < 1e-10
+    assert np.abs(z0[:,1,0]).max() < 1e-10
+    assert np.abs(z0[:,0,0]-z0[:,1,1]).max() < 1e-10
+    assert abs(np.linalg.norm(z0[:,0,0].real)**2-831/289) < 1e-10
+
+    qweA,qweB = numqi.qec.get_weight_enumerator(code, tagB=True)
+    assert np.abs(qweA - info['qweA']).max() < 1e-10
+    assert np.abs(qweB - info['qweB']).max() < 1e-10
+
+    su2 = info['su2']
+    logicalU = code.conj() @ hf_kron(*su2) @ code.T
+    assert np.abs(numqi.gate.rz(-2*np.pi/17) - logicalU).max() < 1e-10
+
+    tmp1 = np.stack([info['basis0'],info['basis1']], axis=0)
+    z1 = np.einsum(tmp1, [0,1,2], tmp1, [3,4,5], hf_kron(*su2), [2,5], [0,3,1,4], optimize=True)
+    assert np.abs(numqi.gate.rz(-2*np.pi/17).reshape(2,2,1,1) * np.eye(8) - z1).max() < 1e-10
+
+
+def test_get_BD36():
+    theta = np_rng.uniform(0, 2*np.pi)
+    sign = np_rng.choice([1,-1], size=7, replace=True)
+    code,info = numqi.qec.q723.get_BD36(sign=sign, theta=theta, return_info=True)
+    error_scipy = numqi.qec.make_pauli_error_list_sparse(7, distance=3, kind='scipy-csr01')[1]
+    z0 = code.conj() @ (error_scipy @ code.T).reshape(-1,128,2)
+    assert np.abs(z0[:,0,1]).max() < 1e-10
+    assert np.abs(z0[:,1,0]).max() < 1e-10
+    assert np.abs(z0[:,0,0]-z0[:,1,1]).max() < 1e-10
+    assert abs(np.linalg.norm(z0[:,0,0].real)**2-161/81) < 1e-10
+    qweA,qweB = numqi.qec.get_weight_enumerator(code, tagB=True)
+    assert np.abs(qweA-info['qweA']).max() < 1e-10
+    assert np.abs(qweB-info['qweB']).max() < 1e-10
+
+    su2 = info['su2']
+    logicalU = code.conj() @ hf_kron(*su2) @ code.T
+    assert np.abs(numqi.gate.rz(-2*np.pi/18) - logicalU).max() < 1e-10
+
+
+def test_get_2O_X5():
+    sign = np_rng.integers(2, size=6)*2 - 1
+    sign[1] = -sign[0]
+    sign[4] = -sign[0]
+    sign[5] = sign[3]
+    code,info = numqi.qec.q723.get_2O_X5(sign=sign, return_info=True)
+
+    error_str,error_scipy = numqi.qec.make_pauli_error_list_sparse(7, distance=3, kind='scipy-csr01')
+    z0 = code.conj() @ (error_scipy @ code.T).reshape(-1,2**7,2)
+    assert np.abs(z0[:,0,1]).max() < 1e-10
+    assert np.abs(z0[:,1,0]).max() < 1e-10
+    assert np.abs(z0[:,0,0] - z0[:,1,1]).max() < 1e-10
+    qweA,qweB = numqi.qec.get_weight_enumerator(code, tagB=True)
+    assert np.abs(qweA - info['qweA']).max() < 1e-10
+    assert np.abs(qweB - info['qweB']).max() < 1e-10
+    logicalU = code.conj() @ hf_kron(*info['su2X']) @ code.T
+    assert np.abs(numqi.gate.X - logicalU).max() < 1e-10
+    logicalU = code.conj() @ hf_kron(*info['su2YSY']) @ code.T
+    # tmp0 = numqi.gate.ry(np.pi/4) @ numqi.gate.rz(np.pi/2) @ numqi.gate.ry(np.pi/4).T
+    tmp0 = numqi.qec.get_su2_finite_subgroup_generator('2Ox')[1]
+    assert np.abs(logicalU-tmp0).max() < 1e-10
+
+

--- a/tests/test_qec/test_q823.py
+++ b/tests/test_qec/test_q823.py
@@ -1,0 +1,107 @@
+import functools
+import numpy as np
+import numqi
+
+np_rng = np.random.default_rng()
+hf_kron = lambda *x: functools.reduce(np.kron, x)
+
+def test_get_BD38_LP():
+    code,info = numqi.qec.q823.get_BD38_LP(return_info=True)
+    error_str,error_scipy = numqi.qec.make_pauli_error_list_sparse(8, distance=3, kind='scipy-csr01')
+    z0 = code.conj() @ (error_scipy @ code.T).reshape(-1,2**8,2)
+    assert np.abs(z0[:,0,1]).max() < 1e-10
+    assert np.abs(z0[:,1,0]).max() < 1e-10
+    assert np.abs(z0[:,0,0] - z0[:,1,1]).max() < 1e-10
+    logicalU = code.conj() @ hf_kron(*info['su2']) @ code.T
+    assert np.abs(numqi.gate.rz(-2*np.pi/19) - logicalU).max() < 1e-10
+
+
+def test_get_BD64():
+    sign = np_rng.integers(2, size=9)*2 - 1
+    theta = np_rng.uniform(0, 2*np.pi, size=3)
+    code,info = numqi.qec.q823.get_BD64(theta, sign, return_info=True)
+    error_str,error_scipy = numqi.qec.make_pauli_error_list_sparse(8, distance=3, kind='scipy-csr01')
+    z0 = code.conj() @ (error_scipy @ code.T).reshape(-1,2**8,2)
+    assert np.abs(z0[:,0,1]).max() < 1e-10
+    assert np.abs(z0[:,1,0]).max() < 1e-10
+    assert np.abs(z0[:,0,0] - z0[:,1,1]).max() < 1e-10
+    logicalU = code.conj() @ hf_kron(*info['su2']) @ code.T
+    assert np.abs(numqi.gate.rz(-2*np.pi/32) - logicalU).max() < 1e-10
+
+
+def test_get_BD72():
+    theta = np_rng.uniform(0, 2*np.pi, size=5)
+    sign = np_rng.integers(2, size=3)*2-1
+    code,info = numqi.qec.q823.get_BD72(theta=theta, sign=sign, return_info=True)
+    error_str,error_scipy = numqi.qec.make_pauli_error_list_sparse(8, distance=3, kind='scipy-csr01')
+    z0 = code.conj() @ (error_scipy @ code.T).reshape(-1,2**8,2)
+    assert np.abs(z0[:,0,1]).max() < 1e-10
+    assert np.abs(z0[:,1,0]).max() < 1e-10
+    assert np.abs(z0[:,0,0] - z0[:,1,1]).max() < 1e-10
+    logicalU = code.conj() @ hf_kron(*info['su2']) @ code.T
+    assert np.abs(numqi.gate.rz(-2*np.pi/36) - logicalU).max() < 1e-10
+
+
+def test_get_BD74():
+    sign = np_rng.integers(2, size=4)*2-1
+    theta = np_rng.uniform(0, 2*np.pi, size=4)
+    code, info = numqi.qec.q823.get_BD74(theta=theta, sign=sign)
+    error_str,error_scipy = numqi.qec.make_pauli_error_list_sparse(8, distance=3, kind='scipy-csr01')
+    z0 = code.conj() @ (error_scipy @ code.T).reshape(-1,2**8,2)
+    assert np.abs(z0[:,0,1]).max() < 1e-10
+    assert np.abs(z0[:,1,0]).max() < 1e-10
+    assert np.abs(z0[:,0,0] - z0[:,1,1]).max() < 1e-10
+    logicalU = code.conj() @ hf_kron(*info['su2']) @ code.T
+    assert np.abs(numqi.gate.rz(-2*np.pi/37) - logicalU).max() < 1e-10
+
+
+def test_get_BD76():
+    theta = np_rng.uniform(0, 2*np.pi, size=6)
+    sign = np_rng.integers(2, size=2)*2-1
+    code, info = numqi.qec.q823.get_BD76(theta=theta, sign=sign, return_info=True)
+    error_str,error_scipy = numqi.qec.make_pauli_error_list_sparse(8, distance=3, kind='scipy-csr01')
+    z0 = code.conj() @ (error_scipy @ code.T).reshape(-1,2**8,2)
+    assert np.abs(z0[:,0,1]).max() < 1e-10
+    assert np.abs(z0[:,1,0]).max() < 1e-10
+    assert np.abs(z0[:,0,0] - z0[:,1,1]).max() < 1e-10
+    logicalU = code.conj() @ hf_kron(*info['su2']) @ code.T
+    assert np.abs(numqi.gate.rz(-2*np.pi/38) - logicalU).max() < 1e-10
+
+
+def test_get_BD78():
+    theta = np_rng.uniform(0, 2*np.pi, size=6)
+    sign = np_rng.integers(2, size=2)*2-1
+    code,info = numqi.qec.q823.get_BD78(theta=theta, sign=sign, return_info=True)
+    error_str,error_scipy = numqi.qec.make_pauli_error_list_sparse(8, distance=3, kind='scipy-csr01')
+    z0 = code.conj() @ (error_scipy @ code.T).reshape(-1,2**8,2)
+    assert np.abs(z0[:,0,1]).max() < 1e-10
+    assert np.abs(z0[:,1,0]).max() < 1e-10
+    assert np.abs(z0[:,0,0] - z0[:,1,1]).max() < 1e-10
+    logicalU = code.conj() @ hf_kron(*info['su2']) @ code.T
+    assert np.abs(numqi.gate.rz(-2*np.pi/39) - logicalU).max() < 1e-10
+
+
+def test_get_BD80():
+    theta = np_rng.uniform(0, 2*np.pi, size=6)
+    sign = np_rng.integers(2, size=2)*2-1
+    code, info = numqi.qec.q823.get_BD80(theta=theta, sign=sign, return_info=True)
+    error_str,error_scipy = numqi.qec.make_pauli_error_list_sparse(8, distance=3, kind='scipy-csr01')
+    z0 = code.conj() @ (error_scipy @ code.T).reshape(-1,2**8,2)
+    assert np.abs(z0[:,0,1]).max() < 1e-10
+    assert np.abs(z0[:,1,0]).max() < 1e-10
+    assert np.abs(z0[:,0,0] - z0[:,1,1]).max() < 1e-10
+    logicalU = code.conj() @ hf_kron(*info['su2']) @ code.T
+    assert np.abs(numqi.gate.rz(-2*np.pi/40) - logicalU).max() < 1e-10
+
+
+def test_get_BD84():
+    theta = np_rng.uniform(0, 2*np.pi, size=7)
+    sign = np_rng.integers(2)*2-1
+    code, info = numqi.qec.q823.get_BD84(theta=theta, sign=sign, return_info=True)
+    error_str,error_scipy = numqi.qec.make_pauli_error_list_sparse(8, distance=3, kind='scipy-csr01')
+    z0 = code.conj() @ (error_scipy @ code.T).reshape(-1,2**8,2)
+    assert np.abs(z0[:,0,1]).max() < 1e-10
+    assert np.abs(z0[:,1,0]).max() < 1e-10
+    assert np.abs(z0[:,0,0] - z0[:,1,1]).max() < 1e-10
+    logicalU = code.conj() @ hf_kron(*info['su2']) @ code.T
+    assert np.abs(numqi.gate.rz(-2*np.pi/42) - logicalU).max() < 1e-10

--- a/tests/test_qec/test_qec_pauli.py
+++ b/tests/test_qec/test_qec_pauli.py
@@ -1,0 +1,41 @@
+import numpy as np
+import numqi
+
+np_rng = np.random.default_rng()
+
+def test_weight_enumerator_transform_matrix():
+    for n in [5,6,7]:
+        mat_dict = numqi.qec.get_weight_enumerator_transform_matrix(n, kind='numpy')
+        for key in ['M', "M1", "M2"]:
+            np0 = mat_dict[key]
+            assert np.abs(np0 @ np0 - np.eye(n+1, dtype=np.float64)).max() < 1e-10, f"self-inverse failed for {key}"
+        for key in ['T1', 'T2', 'T3']:
+            np0 = mat_dict[key]
+            np1 = mat_dict['i' + key]
+            assert np.abs(np0 @ np1 - np.eye(n+1, dtype=np.float64)).max() < 1e-10, f"inverse failed for {key}"
+
+        assert np.abs(mat_dict['T1'] @ mat_dict['M'] @ mat_dict['iT1'] - mat_dict['M1']).max() < 1e-10, "M/M1 relation failed"
+        assert np.abs(mat_dict['T2'] @ mat_dict['M'] @ mat_dict['iT2'] - mat_dict['M2']).max() < 1e-10, "M/M2 relation failed"
+        assert np.abs(mat_dict['T3'] @ mat_dict['M1'] @ mat_dict['iT3'] - mat_dict['M2']).max() < 1e-10, "M1/M2 relation failed"
+
+    # import qsalto #pip install qsalto
+    # n = 7
+    # ret = get_weight_enumerator_transform_matrix(n, kind='numpy')
+    # for key,value in ret.items():
+    #     assert np.abs(getattr(qsalto, key)(n) - value).max() < 1e-10
+
+
+def test_get_knill_laflamme_matrix_indexing_over_vector():
+    index_KL_matrix = numqi.qec.get_knill_laflamme_matrix_indexing_over_vector(num_qubit=7, distance=3)
+
+    code,info = numqi.qec.get_code_subspace('723cyclic', lambda2=np_rng.uniform(0,7))
+    error_scipy = numqi.qec.make_pauli_error_list_sparse(7, distance=3, kind='scipy-csr01')[1]
+    lambda_a = ((error_scipy @ code[0]).reshape(-1,2**7) @ code[0].conj()).real
+    lambda_ab = np.concat([np.ones(1), lambda_a], axis=0)[index_KL_matrix].reshape(-1, round(np.sqrt(index_KL_matrix.size)))
+
+    error_scipy_a = numqi.qec.make_pauli_error_list_sparse(7, distance=2, kind='scipy-csr01')[1]
+    tmp0 = np.concatenate([code[:1],(error_scipy_a @ code[0]).reshape(-1, 2**7)], axis=0)
+    lambda_ab_ = tmp0.conj() @ tmp0.T
+    assert np.abs(lambda_ab_.imag).max() < 1e-12
+    lambda_ab_ = lambda_ab_.real
+    assert np.abs(lambda_ab-lambda_ab_).max() < 1e-12

--- a/tests/test_qec/test_small_code.py
+++ b/tests/test_qec/test_small_code.py
@@ -1,60 +1,8 @@
 import numpy as np
-import scipy.linalg
 
 import numqi
 
 np_rng = np.random.default_rng()
-
-
-def test_get_code_subspace_523():
-    code,info = numqi.qec.get_code_subspace('523')
-    # https://arxiv.org/abs/quant-ph/9610040
-    weightA, weightB = numqi.qec.get_weight_enumerator(code, use_circuit=True)
-    weightA_ = np.array([1,0,0,0,15,0])
-    weightB_ = np.array([1,0,0,30,15,18])
-    assert np.abs(weightA-weightA_).max() < 1e-10
-    assert np.abs(weightB-weightB_).max() < 1e-10
-
-    # https://arxiv.org/abs/2204.03560 (eq132)
-    op_list = numqi.qec.make_pauli_error_list_sparse(num_qubit=6, distance=3, kind='numpy')[1]
-    code623 = np.stack([code,code*0], axis=2).reshape(2,-1)
-    # weightA = [1,1,0,0,15,15,0]; weightB = [1,1,0,30,45,33,18]
-    matU = numqi.random.rand_haar_unitary(2)
-    tmp0 = scipy.linalg.block_diag(np.eye(2), matU)
-    code623a = np.einsum(code623.reshape(-1,4), [0,1], tmp0, [3,1], [0,3], optimize=True).reshape(2,-1)
-    tmp1 = code623.reshape(-1, 4)
-    tmp2 = np.concatenate([tmp1[:,:2], tmp1[:,2:] @ matU.T], axis=1).reshape(2, -1)
-    assert np.abs(tmp2 - code623a).max() < 1e-12
-    z0 = code623a.conj() @ (op_list @ code623a.T)
-    assert np.abs(z0[:,0,1]).max() < 1e-12
-    assert np.abs(z0[:,0,0] - z0[:,1,1]).max() < 1e-12
-    assert abs(np.linalg.norm(z0[:,0,0].real)-1) < 1e-10
-
-
-def test_723bare_code():
-    code,info = numqi.qec.get_code_subspace('723bare')
-    op_list = numqi.qec.make_pauli_error_list_sparse(num_qubit=7, distance=3, kind='numpy')[1]
-    z0 = code.conj() @ (op_list @ code.T)
-    assert np.abs(z0[:,0,1]).max() < 1e-12
-    assert np.abs(z0[:,0,0] - z0[:,1,1]).max() < 1e-12
-    assert abs(np.linalg.norm(z0[:,0,0].real)**2-5) < 1e-10
-    # "XXIIIII XIIIXII IXIIXII IIXIIXI IIIXIIX" is 1
-
-
-def test_723permutation_code():
-    for sign in '+-':
-        code,info = numqi.qec.get_code_subspace('723permutation', sign=sign)
-        op_list = numqi.qec.make_pauli_error_list_sparse(num_qubit=7, distance=3, kind='scipy-csr01')[1]
-        z0 = code.conj() @ (op_list @ code.T).reshape(-1, 2**7, 2)
-        assert np.abs(z0[:,0,1]).max() < 1e-12
-        tmp0 = np.array([2/3]*18 + [1] + [3]*3)
-        ind0 = [21, 25, 29, 30, 34, 38, 39, 43, 47, 48, 52, 56, 57, 61, 65, 66, 70, 74, 75, 79, 83,
-                84, 88, 92, 93, 97, 101, 102, 106, 110, 111, 115, 119, 120, 124, 128, 129, 133, 137,
-                138, 142, 146, 147, 151, 155, 156, 160, 164, 165, 169, 173, 174, 178, 182, 183, 187,
-                191, 192, 196, 200, 201, 205, 209]
-        tmp0 = np.zeros(210, dtype=np.float64)
-        tmp0[ind0] = 1/3
-        assert np.abs(z0[:,0,0]-tmp0).max() < 1e-10
 
 
 def test_442code():
@@ -97,107 +45,8 @@ def test_883code():
     assert np.abs(z0).max() < 1e-10
 
 
-def test_steane_code():
-    code,info = numqi.qec.get_code_subspace('steane')
-    op_list = numqi.qec.make_pauli_error_list_sparse(num_qubit=7, distance=3, kind='scipy-csr01')[1]
-    z0 = code.conj() @ (op_list @ code.T).reshape(-1, 2**7, 2)
-    assert np.abs(z0).max() < 1e-10
-
 def test_code642():
     code,_ = numqi.qec.get_code_subspace('642stab')
     op_list = numqi.qec.make_pauli_error_list_sparse(num_qubit=6, distance=2, kind='scipy-csr01')[1]
     z0 = code.conj() @ (op_list @ code.T).reshape(-1, 2**6, 4)
     assert np.abs(z0).max() < 1e-10
-
-
-def test_623stab_code():
-    op_list = numqi.qec.make_pauli_error_list_sparse(num_qubit=6, distance=3, kind='scipy-csr01')[1]
-    code,_ = numqi.qec.get_code_subspace('623stab')
-    z0 = code.conj() @ (op_list @ code.T).reshape(-1, 2**6, 2)
-    assert np.abs(z0[:,0,1]).max() < 1e-10
-    assert np.abs(z0[:,0,0] - z0[:,1,1]).max() < 1e-10
-    tmp1 = np.zeros(153, dtype=np.float64)
-    tmp1[143] = 1
-    assert np.abs(z0[:,0,0]-tmp1).max() < 1e-12
-    weightA, weightB = numqi.qec.get_weight_enumerator(code, use_circuit=True, tagB=True)
-    weightA_ = np.array([1,0,1,0,11,16,3])
-    weightB_ = np.array([1,0,1,24,35,40,27])
-    assert np.abs(weightA-weightA_).max() < 1e-12
-    assert np.abs(weightB-weightB_).max() < 1e-12
-
-
-def get_MacWilliams_identity(weight, x, y):
-    n = weight.shape[0]-1
-    ret = sum((x**(n-i)) * (y**i) * weight[i] for i in range(n+1))
-    return ret
-
-
-def test_get_code_quantum_weight_enumerator():
-    for key in ['523','shor','steane']:
-        code,info = numqi.qec.get_code_subspace(key)
-        weightA = info['qweA']
-        weightB = info['qweB']
-        dim = code.shape[0]
-        npx = np_rng.uniform(-1, 1, 5)
-        npy = np_rng.uniform(-1, 1, 5)
-        z0 = get_MacWilliams_identity(weightB, npx, npy)
-        z1 = dim * get_MacWilliams_identity(weightA, (npx+3*npy)/2, (npx-npy)/2)
-        # https://arxiv.org/abs/2408.10323 eq(4)
-        assert np.abs(z0-z1).max() < 1e-10
-
-
-def test_get_623_SO5_code_quantum_weight_enumerator():
-    wt_to_pauli_dict = {x:numqi.qec.get_pauli_with_weight_sparse(6,x)[1] for x in range(1,7)}
-    for _ in range(5):
-        vece = numqi.random.rand_haar_state(5, tag_complex=False)
-        code,info = numqi.qec.get_code_subspace('623-SO5', vece=vece)
-        weightA,weightB = numqi.qec.get_weight_enumerator(code, wt_to_pauli_dict=wt_to_pauli_dict)
-        assert np.abs(weightA-info['qweA']).max() < 1e-10
-        assert np.abs(weightB-info['qweB']).max() < 1e-10
-
-
-def test_get_723_cyclic_code():
-    error_str_list,op_list = numqi.qec.make_pauli_error_list_sparse(num_qubit=7, distance=3, kind='scipy-csr01')
-    lambda2 = np_rng.uniform(0, 7)
-    for sign in ['++', '+-', '-+', '--']:
-        coeff,lambda_ai_dict,basis = numqi.qec._small_code.get_723_cyclic_code(lambda2, sign=sign)
-        q0 = coeff @ basis
-        z0 = q0.conj() @ (op_list @ q0.T).reshape(-1, 2**7, 2)
-        assert np.abs(z0.imag).max() < 1e-12
-        assert np.abs(z0[:,0,1]).max() < 1e-12
-        assert np.abs(z0[:,1,0]).max() < 1e-12
-        assert np.abs(z0[:,0,0] - z0[:,1,1]).max() < 1e-12
-        z0 = z0[:,0,0].real
-        z1 = np.array([lambda_ai_dict.get(x,0) for x in error_str_list])
-        assert np.abs(z0-z1).max() < 1e-12
-
-
-def test_723_cyclic_code_weight_enumerator():
-    wt_to_pauli_dict = {x:numqi.qec.get_pauli_with_weight_sparse(7,x)[1] for x in range(1,8)} #slow 11 seconds
-    for _ in range(5):
-        lambda2 = np_rng.uniform(0, 7)
-        code,info = numqi.qec.get_code_subspace('723cyclic', lambda2=lambda2)
-        weightA,weightB = numqi.qec.get_weight_enumerator(code, wt_to_pauli_dict=wt_to_pauli_dict)
-        assert np.abs(weightA-info['qweA']).max() < 1e-10
-        assert np.abs(weightB-info['qweB']).max() < 1e-10
-
-    code523,info = numqi.qec.get_code_subspace('523')
-    code723 = np.concatenate([code523.reshape(2,32,1), np.zeros((2,32,3))], axis=2).reshape(2,128)
-    weightA,weightB = numqi.qec.get_weight_enumerator(code723, wt_to_pauli_dict=wt_to_pauli_dict)
-    weightA_ = np.array([1,2,1,0,15,30,15,0])
-    weightB_ = np.array([1,2,1,30,75,78,51,18])
-    assert np.abs(weightA-weightA_).max() < 1e-10
-    assert np.abs(weightB-weightB_).max() < 1e-10
-
-
-def test_723permutation_code_local_unitary_equivalent():
-    codep,info = numqi.qec.get_code_subspace('723permutation', sign='+')
-    codem,info = numqi.qec.get_code_subspace('723permutation', sign='-')
-    model = numqi.qec.QECCEqualModel(codep, codem)
-    # theta0 = numqi.optimize.minimize(model, 'uniform', num_repeat=10, tol=1e-24).x
-    theta0 = np.array([-0.9851071268903094, 0.9851071309835814, -0.9851071080929052, 0.8286922424445572, -0.8286922385150921,
-            0.8286922425522644, 0.8286922410131242, -0.8286922420980595, 0.8286922443320521, 0.8286922422542674, -0.8286922398812964,
-            0.8286922415662342, -0.9851071239082392, 0.9851071216442577, -0.9851071202221557, -0.9851071170253412, 0.9851071293328815,
-            -0.9851071218120353, -0.9851071289119772, 0.9851071116144996, -0.985107125489987])
-    numqi.optimize.set_model_flat_parameter(model, theta0)
-    assert abs(model().item()) < 1e-12

--- a/tests/test_qec/test_transversal.py
+++ b/tests/test_qec/test_transversal.py
@@ -1,0 +1,122 @@
+import numpy as np
+import functools
+
+import numqi
+
+np_rng = np.random.default_rng()
+hf_kron = lambda *x: functools.reduce(np.kron, x)
+
+def test_transversal_group_723cyclic():
+    Phi = numqi.qec.su2_finite_subgroup_gate_dict['Phi']
+    Phis = numqi.qec.su2_finite_subgroup_gate_dict['Phi*']
+    for sign in ['++','+-','-+','--']:
+        code,info = numqi.qec.get_code_subspace('723cyclic', lambda2=np_rng.uniform(0, 7), sign=sign)
+        assert np.abs(code @ numqi.qec.hf_pauli('X'*7) @ code.T - numqi.gate.X).max() < 1e-12
+        F = numqi.qec.su2_finite_subgroup_gate_dict['F']
+        assert np.abs(code @ hf_kron(*[F.conj()]*7) @ code.T - F).max() < 1e-12
+
+        code,info = numqi.qec.get_code_subspace('723cyclic', lambda2=0, sign=sign)
+        S = numqi.gate.rz(np.pi/2)
+        assert np.abs(code @ hf_kron(*[S.conj()]*7) @ code.T - S).max() < 1e-12
+
+        code,info = numqi.qec.get_code_subspace('723cyclic', lambda2=7, sign=sign)
+        if sign[0]=='+':
+            assert np.abs(code @ hf_kron(*[Phi]*7) @ code.T - Phis).max() < 1e-12
+        else:
+            assert np.abs(code @ hf_kron(*[Phis]*7) @ code.T - Phi).max() < 1e-12
+
+
+def test_su2_finite_subgroup_gate_dict():
+    for x in numqi.qec.su2_finite_subgroup_gate_dict.values():
+        assert abs(x[0,0]*x[1,1] - x[0,1]*x[1,0] - 1) < 1e-10 #determinant 1
+        assert np.abs(x @ x.T.conj() - np.eye(2)).max() < 1e-10
+
+
+def test_su2_finite_subgroup():
+    np_list = numqi.group.get_complete_group(numqi.qec.get_su2_finite_subgroup_generator('2T'))
+    assert len(np_list)==24
+    info = numqi.qec.get_transversal_group_info(np_list)
+    assert np.all(info['dim_irrep']==np.array([1,1,1,2,2,2,3], dtype=np.int64))
+    assert np.all(info['num_class']==np.array([1,1,4,4,4,4,6], dtype=np.int64))
+    # numqi.group.pretty_print_character_table(info['character_table'], info['class_list'])
+
+    # 2O, clifford
+    np_list = numqi.group.get_complete_group(numqi.qec.get_su2_finite_subgroup_generator('2O'))
+    assert len(np_list)==48
+    info = numqi.qec.get_transversal_group_info(np_list)
+    assert np.all(info['dim_irrep']==np.array([1,1,2,2,2,3,3,4], dtype=np.int64))
+    assert np.all(info['num_class']==np.array([1,1,6,6,6,8,8,12], dtype=np.int64))
+
+    # 2I (slow)
+    np_list = numqi.group.get_complete_group(numqi.qec.get_su2_finite_subgroup_generator('2I'))
+    assert len(np_list)==120
+    # info = numqi.qec.get_transversal_group_info(np_list)
+    # assert np.all(info['dim_irrep']==np.array([1,2,2,3,3,4,4,5,6], dtype=np.int64))
+    # assert np.all(info['num_class']==np.array([1,1,12,12,12,12,20,20,30], dtype=np.int64))
+
+    # BD_2n
+    for n in range(1,7):
+        np_list = numqi.group.get_complete_group(numqi.qec.get_su2_finite_subgroup_generator('BD'+str(2*n)))
+        assert len(np_list)==4*n
+        info = numqi.qec.get_transversal_group_info(np_list)
+        tmp0 = np.array([1,1,1,1] + [2]*(n-1), dtype=np.int64)
+        assert np.all(info['dim_irrep']==tmp0)
+        tmp0 = np.array([1,1] + [2]*(n-1) + [n,n], dtype=np.int64)
+        assert np.all(info['num_class']==tmp0)
+
+    # C_2n
+    # np_list = numqi.group.get_complete_group(numqi.qec.get_su2_finite_subgroup_generator('C'+str(2*n)))
+
+
+def test_super_golden_gate():
+    a = (1+np.sqrt(5))/2
+    tau60 = np.array([[2+a, 1-1j], [1+1j, -2-a]])/np.sqrt(5*a+7)
+
+    assert np.abs(tau60 @ tau60 - np.eye(2)).max() < 1e-12 #self-inverse
+    assert np.abs(tau60 @ tau60.T.conj() - np.eye(2)).max() < 1e-12 #unitary
+
+    rz = numqi.gate.rz
+    tmp0 = 2*np.arccos((2+a)/np.sqrt(5*a+7))
+    tmp1a = 1j*rz(np.pi/4) @ numqi.gate.ry(tmp0) @ rz(3*np.pi/4)
+    assert np.abs(tmp1a - tau60).max() < 1e-12
+    tmp1b = rz(np.pi/4) @ rz(np.pi/2) @ numqi.gate.H @ rz(tmp0) @ numqi.gate.H @ rz(-np.pi/2) @ numqi.gate.Z @ rz(-np.pi/4)
+    assert np.abs(tmp1b - tau60).max() < 1e-12
+    tmp1c = 1j * rz(3*np.pi/4) @ numqi.gate.H @ rz(tmp0) @ numqi.gate.H @ rz(np.pi/4)
+    assert np.abs(tmp1c - tau60).max() < 1e-12
+    # tmp1d = 1j * rz(3*np.pi/4) @ numqi.gate.H @ rz(np.pi*167/704) @ numqi.gate.H @ rz(np.pi/4)
+
+
+def test_search_veca_C_group():
+    x0 = numqi.qec.search_veca_C_group(n=6, m=5, tag_print=False)
+    x1 = {(0,1,1,2,2,3),(0,1,3,3,3,4),(0,2,2,2,4,4),(1,1,1,1,1,4),(1,1,1,1,2,3),(1,1,1,2,2,2),
+        (1,1,1,2,2,3),(1,1,2,2,2,3),(1,1,2,2,3,3),(1,1,2,2,3,4),(1,1,2,2,4,4),(1,1,2,3,3,4),
+        (1,1,3,3,3,3),(1,1,3,3,3,4),(1,2,2,2,3,4),(1,2,2,2,4,4),(1,2,2,3,3,3),(1,2,3,3,3,4),
+        (1,3,3,3,3,4),(1,3,3,3,4,4),(1,3,3,4,4,4),(2,2,2,2,2,4),(2,2,2,2,4,4),(2,2,2,3,4,4),
+        (2,2,2,4,4,4),(2,2,3,4,4,4),(2,3,3,3,4,4),(2,3,3,4,4,4),(3,3,3,3,3,4),(4,4,4,4,4,4)}
+    # (1,1,1,1,2,3) has KL solution
+    tmp0 = {tuple(y) for y in x0}
+    assert tmp0==x1
+
+    ## empty but too slow
+    #x0 = numqi.qec.search_veca_C_group(n=7, m=19)
+
+
+def test_search_veca_BD_group():
+    x0 = numqi.qec.search_veca_BD_group(n=7, m=17, k=2, tag_print=False)
+    x1 = {(3, 3, 4, 5, 5, 6, 7), (2, 2, 3, 4, 5, 8, 9), (1, 2, 4, 4, 6, 7, 9)}
+    assert {tuple(y) for y in x0}==x1
+
+    x0 = numqi.qec.search_veca_BD_group(n=7, m=18, k=2, tag_print=False)
+    x1 = {(2, 3, 4, 5, 6, 7, 8)}
+    assert {tuple(y) for y in x0}==x1
+
+    x0 = numqi.qec.search_veca_BD_group(n=6, m=5, k=None, tag_print=False)
+    x1 = {(0,1,1,2,2,3),(0,1,3,3,3,4),(0,2,2,2,4,4),(1,1,1,1,1,4),(1,1,1,1,2,3),(1,1,1,2,2,2),
+          (1,1,2,2,4,4),(1,1,2,3,3,4),(1,1,3,3,3,3),(1,2,2,2,3,4),(1,2,2,3,3,3),(1,3,3,4,4,4),
+          (2,2,2,2,2,4),(2,2,3,4,4,4),(2,3,3,3,4,4),(3,3,3,3,3,4),(4,4,4,4,4,4)}
+    assert {tuple(y) for y in x0}==x1
+
+    x0 = numqi.qec.search_veca_BD_group(n=7, m=18, k=None, tag_print=False)
+    x1 = {(2,3,4,5,6,7,8),(2,3,4,8,11,12,13),(2,3,5,7,10,12,14),(2,4,5,6,10,11,15),
+          (2,7,8,12,13,14,15),(3,6,8,11,13,14,16),(4,5,8,11,12,15,16),(4,6,7,10,13,15,16)}
+    assert {tuple(y) for y in x0}==x1

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -21,7 +21,7 @@ def test_QueryGroverModel():
         (4, 2, 0.09155), #3s
         (4, 3, 0), #2s
         # (5, 3, 0.1031), #30s
-        (5, 4, 0), #13s
+        # (5, 4, 0), #13s
     ]
     for num_qubit,num_query,ret_ in case_list:
         model = numqi.query.QueryGroverModel(num_qubit, num_query, use_fractional=False, dtype='float64')
@@ -51,17 +51,18 @@ def _QueryGroverQuantumModel_build_circuit(num_qubit, num_layer, num_query, use_
     return circ
 
 
-def test_QueryGroverQuantumModel():
-    case_list = [
-        (3, 2, 8, 0, 233), #about 20 seconds (1 round)
-        # (4, 3, 24, 0, None), #about 400 steps
-    ]
-    kwargs = dict(theta0=('uniform', 0, 2*np.pi), tol=1e-9, num_repeat=1, print_every_round=0, print_freq=50, early_stop_threshold=1e-7)
-    for num_qubit,num_query,num_layer,ret_,seed in case_list:
-        circuit = _QueryGroverQuantumModel_build_circuit(num_qubit, num_layer, num_query, use_fractional=False)
-        model = numqi.query.QueryGroverQuantumModel(circuit)
-        theta_optim = numqi.optimize.minimize(model, seed=seed, **kwargs)
-        assert abs(model.error_rate-ret_) < 1e-4
+## TOO slow
+# def test_QueryGroverQuantumModel():
+#     case_list = [
+#         (3, 2, 8, 0, 233), #about 20 seconds (1 round)
+#         # (4, 3, 24, 0, None), #about 400 steps
+#     ]
+#     kwargs = dict(theta0=('uniform', 0, 2*np.pi), tol=1e-9, num_repeat=1, print_every_round=0, print_freq=50, early_stop_threshold=1e-7)
+#     for num_qubit,num_query,num_layer,ret_,seed in case_list:
+#         circuit = _QueryGroverQuantumModel_build_circuit(num_qubit, num_layer, num_query, use_fractional=False)
+#         model = numqi.query.QueryGroverQuantumModel(circuit)
+#         theta_optim = numqi.optimize.minimize(model, seed=seed, **kwargs)
+#         assert abs(model.error_rate-ret_) < 1e-4
 
 
 def test_grover_sdp():

--- a/tests/tests_group/test_group_lie.py
+++ b/tests/tests_group/test_group_lie.py
@@ -1,5 +1,6 @@
 import numpy as np
 import scipy.special
+import torch
 
 import numqi
 
@@ -106,3 +107,92 @@ def test_get_rational_orthogonal2_matrix():
             if (m!=0) and (n!=0) and (abs(m)!=abs(n)):
                 tmp0 = numqi.group.get_rational_orthogonal2_matrix(m, n)
                 assert abs(tmp0 @ tmp0.T-np.eye(2)).max() < 1e-10
+
+
+def test_su2su2_to_so4_magic():
+    np0,np1 = numqi.random.rand_special_orthogonal_matrix(2, batch_size=2, tag_complex=True)
+    np2 = numqi.group.su2su2_to_so4_magic(np0, np1)
+    assert np.abs(numqi.group.su2su2_to_so4_magic(-np0, -np1)-np2).max() < 1e-10 #2-to-1 mapping
+    assert np.abs(np2 @ np2.T - np.eye(4)).max() < 1e-10
+    assert np.linalg.det(np2) > 0
+    np3, np4 = numqi.group.so4_to_su2su2_magic(np2)
+    tmp0 = max(np.abs(np3-np0).max(), np.abs(np4-np1).max())
+    tmp1 = max(np.abs(np3+np0).max(), np.abs(np4+np1).max())
+    assert min(tmp0, tmp1) < 1e-10
+
+
+def test_su2_to_so3_magic():
+    np0 = numqi.random.rand_special_orthogonal_matrix(2, tag_complex=True)
+    np1 = numqi.group.su2_to_so3_magic(np0)
+    assert np.abs(numqi.group.su2_to_so3_magic(-np0)-np1).max() < 1e-10 #2-to-1 mapping
+    assert np.abs(np1 @ np1.T - np.eye(3)).max() < 1e-10
+    assert np.linalg.det(np1) > 0
+    np2 = numqi.group.so3_to_su2_magic(np1)
+    assert np.abs(np2@np2.T.conj()-np.eye(2)).max() < 1e-10
+    assert min(np.abs(np2-np0).max(), np.abs(np2+np0).max()) < 1e-10
+
+
+def test_SUn_real_imag_part():
+    # https://arxiv.org/abs/quant-ph/0507171v1 eq(15)
+    np0 = numqi.random.rand_haar_unitary(3) #U(n) not SU(n)
+    tmp0 = np0.imag.T @ np0.real
+    assert np.abs(tmp0-tmp0.T).max() < 1e-10
+    tmp0 = np0.imag @ np0.real.T
+    assert np.abs(tmp0-tmp0.T).max() < 1e-10
+
+
+def test_diagonalize_unitary_using_two_orthogonals():
+    np0 = numqi.random.rand_haar_unitary(6)
+    Qleft, D, Qright = numqi.group.diagonalize_unitary_using_two_orthogonals(np0)
+    assert np.abs(Qleft.imag).max() < 1e-10
+    assert np.abs(Qright.imag).max() < 1e-10
+    assert np.abs(Qleft @ Qleft.T - np.eye(np0.shape[0])).max() < 1e-10
+    assert np.abs(Qright @ Qright.T - np.eye(np0.shape[0])).max() < 1e-10
+    assert np.abs(np.abs(D) - 1).max() < 1e-10
+    assert np.abs(np0 - (Qleft*D) @ Qright.T).max()
+
+
+def test_get_su4_kak_decomposition():
+    for _ in range(100):
+        np0 = numqi.random.rand_haar_unitary(4)
+        A0,A1,B0,B1,vecK,diag = numqi.group.get_su4_kak_decomposition(np0)
+        tmp0 = numqi.group.get_kak_kernel(vecK[1:]) * np.exp(1j*vecK[0])
+        assert np.abs(np.kron(A0,A1) @ tmp0 @ np.kron(B0,B1) - np0).max() < 1e-10
+        tmp0 = vecK[1:] / (np.pi/2)
+        assert (1>=tmp0[0]) and (tmp0[0]>=tmp0[1]) and (tmp0[1]>=tmp0[2]) and (tmp0[2]>=0) and (tmp0[0]+tmp0[1]<=1)
+
+    A0,A1,B0,B1,vecK,diag = numqi.group.get_su4_kak_decomposition(numqi.gate.CNOT)
+    tmp0 = vecK[1:]/(np.pi/2)
+    assert np.abs(tmp0-np.array([1/2,0,0])).max() < 1e-10
+
+    A0,A1,B0,B1,vecK,diag = numqi.group.get_su4_kak_decomposition(numqi.gate.Swap)
+    tmp0 = vecK[1:]/(np.pi/2)
+    assert np.abs(tmp0-np.array([1/2,1/2,1/2])).max() < 1e-10
+
+
+def test_get_kak_kernel():
+    vecK = np_rng.normal(size=3)
+    ret_ = scipy.linalg.expm(1j*(vecK[0]*numqi.group._lie._getX('XX')
+            + vecK[1]*numqi.group._lie._getX('YY') + vecK[2]*numqi.group._lie._getX('ZZ')))
+    np0 = numqi.group.get_kak_kernel(vecK)
+    assert np.abs(np0-ret_).max() < 1e-10
+    np1 = numqi.group.get_kak_kernel(torch.tensor(vecK, dtype=torch.float64)).numpy()
+    assert np.abs(np1-ret_).max() < 1e-10
+
+
+def test_KAK_gamma():
+    # https://arxiv.org/abs/quant-ph/0507171v1 eq(32)
+    XX = numqi.group._lie._getX('XX')
+    YY = numqi.group._lie._getX('YY')
+    ZZ = numqi.group._lie._getX('ZZ')
+    magic = numqi.group._lie._getX('magic')
+    assert np.abs(magic @ magic.T.conj() - np.eye(4)).max() < 1e-10
+    XX = np.kron(numqi.gate.X, numqi.gate.X)
+    YY = np.kron(numqi.gate.Y, numqi.gate.Y)
+    ZZ = np.kron(numqi.gate.Z, numqi.gate.Z)
+    gamma = np.array([[1,1,-1,1], [1,1,1,-1], [1,-1,-1,-1], [1,-1,1,1]])
+    assert np.abs(gamma @ gamma.T - 4*np.eye(4)).max() < 1e-10
+    vecK = np_rng.normal(size=4)
+    np0 = magic.T.conj() @ scipy.linalg.expm(1j*(vecK[1]*XX + vecK[2]*YY + vecK[3]*ZZ)) * np.exp(1j*vecK[0]) @ magic
+    np1 = np.diag(np.exp(1j*(gamma @ vecK)))
+    assert np.abs(np0-np1).max() < 1e-10


### PR DESCRIPTION
This pull request introduces significant updates to the `numqi` library, including enhancements to functionality, new features for data storage and manipulation, optimizations for computational speed, and extensions to group theory operations. The most important changes are grouped into themes below:

### Installation and Dependencies Updates:
* Updated the installation instructions in `docs/installation.md` to include additional dependencies such as `h5py`, `platformdirs`, and `pytorch`, among others, for expanded functionality.
* Added new dependencies (`galois`, `platformdirs`, `h5py`) to `pyproject.toml` for compatibility with new features.

### Data Storage and Management:
* Introduced `_internal.py` to handle data storage using HDF5 files. Added methods for saving, loading, and deleting data from disk, supporting both `numpy` arrays and `scipy` sparse matrices.
* Added a utility function `get_savepath()` to dynamically determine the file path for data storage.

### Quantum Computation Enhancements:
* Optimized the `get_dicke_basis` function in `dicke.py` for faster computation when `dim=2`, reducing memory usage and improving speed.
* Added new functions `get_qubit_dicke_rdm_tensor` and `get_qubit_dicke_rdm_pauli_tensor` for advanced tensor manipulation in quantum computations.

### Group Theory Extensions:
* Expanded group theory functionality in `_lie.py` with methods for SU(4) KAK decomposition, SO(4) to SU(2)SU(2) transformations, and diagonalization of unitary matrices using orthogonals.
* Added `get_complete_group` in `_internal.py` to construct complete groups from a list of matrices.

### Documentation and Miscellaneous Improvements:
* Updated documentation for `get_ppt_ree` in `ppt.py`, providing detailed explanations of the relative entropy of entanglement (REE) calculation using the PPT criterion.
* Clarified comments in `check_reduction_witness` to note equivalence to SEP for small dimensions.